### PR TITLE
feat: add notification listeners + register in EventServiceProvider

### DIFF
--- a/app/Listeners/SendAuctionTradingStartedNotification.php
+++ b/app/Listeners/SendAuctionTradingStartedNotification.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\AuctionTradingStarted;
+use App\Notifications\AuctionTradingStartedNotification;
+use Illuminate\Support\Facades\Notification;
+
+class SendAuctionTradingStartedNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(AuctionTradingStarted $event): void
+    {
+        $auction = $event->auction;
+
+        // Получаем все начальные заявки (type = 'initial')
+        $initialBids = $auction->bids()
+            ->where('type', 'initial')
+            ->with('company.moderators')
+            ->get();
+
+        // Собираем всех модераторов компаний-участников
+        $moderators = collect();
+        foreach ($initialBids as $bid) {
+            $moderators = $moderators->merge($bid->company->moderators);
+        }
+
+        // Убираем дубликаты
+        $moderators = $moderators->unique('id');
+
+        // Отправляем уведомления
+        if ($moderators->isNotEmpty()) {
+            Notification::send($moderators, new AuctionTradingStartedNotification($auction));
+        }
+    }
+}

--- a/app/Listeners/SendCommentNotification.php
+++ b/app/Listeners/SendCommentNotification.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\CommentCreated;
+use App\Notifications\NewCommentNotification;
+use Illuminate\Support\Facades\Notification;
+
+class SendCommentNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(CommentCreated $event): void
+    {
+        $comment = $event->comment;
+        $project = $comment->project;
+
+        // Получаем всех участников проекта (компании)
+        $participantCompanies = $project->participants;
+
+        // Собираем всех модераторов всех компаний-участников
+        $moderators = collect();
+        foreach ($participantCompanies as $company) {
+            $moderators = $moderators->merge($company->moderators);
+        }
+
+        // Убираем автора комментария из списка получателей
+        $moderators = $moderators->reject(function ($user) use ($comment) {
+            return $user->id === $comment->user_id;
+        });
+
+        // Убираем дубликаты (если модератор в нескольких компаниях)
+        $moderators = $moderators->unique('id');
+
+        // Отправляем уведомления
+        if ($moderators->isNotEmpty()) {
+            Notification::send($moderators, new NewCommentNotification($comment));
+        }
+    }
+}

--- a/app/Listeners/SendProjectInvitationNotification.php
+++ b/app/Listeners/SendProjectInvitationNotification.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\ProjectInvitationSent;
+use App\Notifications\ProjectInvitationNotification;
+use Illuminate\Support\Facades\Notification;
+
+class SendProjectInvitationNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(ProjectInvitationSent $event): void
+    {
+        // Получаем всех модераторов приглашённой компании
+        $moderators = $event->invitedCompany->moderators;
+
+        // Отправляем уведомление каждому модератору
+        Notification::send($moderators, new ProjectInvitationNotification($event->project));
+    }
+}

--- a/app/Listeners/SendTenderClosedNotification.php
+++ b/app/Listeners/SendTenderClosedNotification.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\TenderClosed;
+use App\Notifications\TenderClosedNotification;
+use Illuminate\Support\Facades\Notification;
+
+class SendTenderClosedNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(TenderClosed $event): void
+    {
+        $tender = $event->tender;
+        $tenderType = $event->tenderType;
+        $winnerCompanyId = $event->winnerCompanyId;
+
+        // Получаем все заявки
+        $bids = $tender->bids()->with('company.moderators')->get();
+
+        foreach ($bids as $bid) {
+            $isWinner = $bid->company_id === $winnerCompanyId;
+            $moderators = $bid->company->moderators;
+
+            // Отправляем уведомление модераторам компании
+            Notification::send(
+                $moderators,
+                new TenderClosedNotification($tender, $tenderType, $isWinner)
+            );
+        }
+    }
+}

--- a/app/Listeners/SendTenderInvitationNotification.php
+++ b/app/Listeners/SendTenderInvitationNotification.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\TenderInvitationSent;
+use App\Notifications\TenderInvitationNotification;
+use Illuminate\Support\Facades\Notification;
+
+class SendTenderInvitationNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(TenderInvitationSent $event): void
+    {
+        // Получаем всех модераторов приглашённой компании
+        $moderators = $event->invitedCompany->moderators;
+
+        // Отправляем уведомление каждому модератору
+        Notification::send(
+            $moderators, 
+            new TenderInvitationNotification($event->tender, $event->tenderType)
+        );
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,11 +5,27 @@ namespace App\Providers;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Socialite\Contracts\Factory as SocialiteFactory;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\URL;
+
 use App\Models\Rfq;
 use App\Policies\RfqPolicy;
-use Illuminate\Support\Facades\URL;
 use App\Models\Auction;
 use App\Policies\AuctionPolicy;
+
+// Events
+use App\Events\ProjectInvitationSent;
+use App\Events\TenderInvitationSent;
+use App\Events\CommentCreated;
+use App\Events\TenderClosed;
+use App\Events\AuctionTradingStarted;
+
+// Listeners
+use App\Listeners\SendProjectInvitationNotification;
+use App\Listeners\SendTenderInvitationNotification;
+use App\Listeners\SendCommentNotification;
+use App\Listeners\SendTenderClosedNotification;
+use App\Listeners\SendAuctionTradingStartedNotification;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -43,5 +59,31 @@ class AppServiceProvider extends ServiceProvider
 
         // Регистрация Policy для Auction
         Gate::policy(Auction::class, AuctionPolicy::class);
+
+                // ========== EVENT LISTENERS ==========
+        Event::listen(
+            ProjectInvitationSent::class,
+            SendProjectInvitationNotification::class
+        );
+
+        Event::listen(
+            TenderInvitationSent::class,
+            SendTenderInvitationNotification::class
+        );
+
+        Event::listen(
+            CommentCreated::class,
+            SendCommentNotification::class
+        );
+
+        Event::listen(
+            TenderClosed::class,
+            SendTenderClosedNotification::class
+        );
+
+        Event::listen(
+            AuctionTradingStarted::class,
+            SendAuctionTradingStartedNotification::class
+        );
     }
 }


### PR DESCRIPTION
# feat: listeners для отправки уведомлений + регистрация в EventServiceProvider

## Что сделано?

- Созданы listeners для всех ключевых событий:
  - SendProjectInvitationNotification
  - SendTenderInvitationNotification
  - SendCommentNotification
  - SendTenderClosedNotification
  - SendAuctionTradingStartedNotification
- Зарегистрированы все пары событие → listener в `EventServiceProvider`
- В listeners добавлена базовая заготовка под отправку уведомлений (пока закомментированы реальные вызовы)

## Как проверить?

1. Запустить тестовое событие в tinker:
```php
$project = App\Models\Project::find(1);
$company = App\Models\Company::find(2);
event(new App\Events\ProjectInvitationSent($project, $company, "Приглашаем вас к участию!"));