### PR TITLE
feat(search): внедрение Laravel Scout с database-драйвером для MVP-по…

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Models\Company;
+use App\Models\Project;
+use App\Models\Rfq;
+use App\Models\Auction;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+
+class SearchController extends Controller
+{
+    /**
+     * Глобальный поиск по всем сущностям
+     */
+    public function index(Request $request)
+    {
+        $query = $request->get('q', '');
+        $type = $request->get('type', 'all');
+
+        if (strlen($query) < 2) {
+            return view('search.index', [
+                'query' => $query,
+                'type' => $type,
+                'results' => collect(),
+                'counts' => $this->getEmptyCounts(),
+            ]);
+        }
+
+        $results = $this->performSearch($query, $type);
+        $counts = $this->getSearchCounts($query);
+
+        return view('search.index', [
+            'query' => $query,
+            'type' => $type,
+            'results' => $results,
+            'counts' => $counts,
+        ]);
+    }
+
+    /**
+     * AJAX-поиск для быстрых результатов (dropdown в хедере)
+     */
+    public function quick(Request $request)
+    {
+        $query = $request->get('q', '');
+
+        if (strlen($query) < 2) {
+            return response()->json(['results' => []]);
+        }
+
+        $results = [];
+
+        // Компании (максимум 3)
+        $companies = Company::search($query)->take(3)->get();
+        foreach ($companies as $company) {
+            $results[] = [
+                'type' => 'company',
+                'type_label' => 'Компания',
+                'id' => $company->id,
+                'title' => $company->name,
+                'subtitle' => $company->inn ? "ИНН: {$company->inn}" : null,
+                'url' => route('companies.show', $company),
+            ];
+        }
+
+        // Проекты (максимум 3)
+        $projects = Project::search($query)->take(3)->get();
+        foreach ($projects as $project) {
+            $results[] = [
+                'type' => 'project',
+                'type_label' => 'Проект',
+                'id' => $project->id,
+                'title' => $project->name,
+                'subtitle' => $project->company?->name,
+                'url' => route('projects.show', $project->slug ?? $project->id),
+            ];
+        }
+
+        // RFQ (максимум 2)
+        $rfqs = Rfq::search($query)->take(2)->get();
+        foreach ($rfqs as $rfq) {
+            $results[] = [
+                'type' => 'rfq',
+                'type_label' => 'Запрос котировок',
+                'id' => $rfq->id,
+                'title' => $rfq->title,
+                'subtitle' => $rfq->number,
+                'url' => route('rfqs.show', $rfq),
+            ];
+        }
+
+        // Аукционы (максимум 2)
+        $auctions = Auction::search($query)->take(2)->get();
+        foreach ($auctions as $auction) {
+            $results[] = [
+                'type' => 'auction',
+                'type_label' => 'Аукцион',
+                'id' => $auction->id,
+                'title' => $auction->title,
+                'subtitle' => $auction->number,
+                'url' => route('auctions.show', $auction),
+            ];
+        }
+
+        return response()->json([
+            'results' => $results,
+            'total' => count($results),
+            'query' => $query,
+        ]);
+    }
+
+    /**
+     * Выполнить поиск по указанному типу
+     */
+    protected function performSearch(string $query, string $type): Collection
+    {
+        $results = collect();
+
+        switch ($type) {
+            case 'users':
+                $results = User::search($query)->take(50)->get()->map(fn($item) => $this->formatUser($item));
+                break;
+
+            case 'companies':
+                $results = Company::search($query)->take(50)->get()->map(fn($item) => $this->formatCompany($item));
+                break;
+
+            case 'projects':
+                $results = Project::search($query)->take(50)->get()->map(fn($item) => $this->formatProject($item));
+                break;
+
+            case 'rfqs':
+                $results = Rfq::search($query)->take(50)->get()->map(fn($item) => $this->formatRfq($item));
+                break;
+
+            case 'auctions':
+                $results = Auction::search($query)->take(50)->get()->map(fn($item) => $this->formatAuction($item));
+                break;
+
+            default: // 'all'
+                $results = collect()
+                    ->merge(User::search($query)->take(10)->get()->map(fn($item) => $this->formatUser($item)))
+                    ->merge(Company::search($query)->take(10)->get()->map(fn($item) => $this->formatCompany($item)))
+                    ->merge(Project::search($query)->take(10)->get()->map(fn($item) => $this->formatProject($item)))
+                    ->merge(Rfq::search($query)->take(10)->get()->map(fn($item) => $this->formatRfq($item)))
+                    ->merge(Auction::search($query)->take(10)->get()->map(fn($item) => $this->formatAuction($item)));
+                break;
+        }
+
+        return $results;
+    }
+
+    /**
+     * Получить количество результатов по каждому типу
+     */
+    protected function getSearchCounts(string $query): array
+    {
+        return [
+            'all' => 0, // Будет рассчитано на основе суммы
+            'users' => User::search($query)->count(),
+            'companies' => Company::search($query)->count(),
+            'projects' => Project::search($query)->count(),
+            'rfqs' => Rfq::search($query)->count(),
+            'auctions' => Auction::search($query)->count(),
+        ];
+    }
+
+    /**
+     * Пустые счётчики для пустого запроса
+     */
+    protected function getEmptyCounts(): array
+    {
+        return [
+            'all' => 0,
+            'users' => 0,
+            'companies' => 0,
+            'projects' => 0,
+            'rfqs' => 0,
+            'auctions' => 0,
+        ];
+    }
+
+    /**
+     * Форматирование пользователя
+     */
+    protected function formatUser(User $user): array
+    {
+        return [
+            'type' => 'user',
+            'type_label' => 'Пользователь',
+            'icon' => 'user',
+            'id' => $user->id,
+            'title' => $user->name,
+            'subtitle' => $user->position,
+            'description' => $user->bio,
+            'url' => route('profile.edit'), // TODO: Публичный профиль пользователя
+            'avatar' => $user->avatar,
+        ];
+    }
+
+    /**
+     * Форматирование компании
+     */
+    protected function formatCompany(Company $company): array
+    {
+        return [
+            'type' => 'company',
+            'type_label' => 'Компания',
+            'icon' => 'building',
+            'id' => $company->id,
+            'title' => $company->name,
+            'subtitle' => $company->inn ? "ИНН: {$company->inn}" : null,
+            'description' => $company->short_description,
+            'url' => route('companies.show', $company),
+            'avatar' => $company->logo_url,
+            'is_verified' => $company->is_verified,
+        ];
+    }
+
+    /**
+     * Форматирование проекта
+     */
+    protected function formatProject(Project $project): array
+    {
+        return [
+            'type' => 'project',
+            'type_label' => 'Проект',
+            'icon' => 'folder',
+            'id' => $project->id,
+            'title' => $project->name,
+            'subtitle' => $project->company?->name,
+            'description' => $project->description,
+            'url' => route('projects.show', $project->slug ?? $project->id),
+            'status' => $project->status,
+        ];
+    }
+
+    /**
+     * Форматирование RFQ
+     */
+    protected function formatRfq(Rfq $rfq): array
+    {
+        return [
+            'type' => 'rfq',
+            'type_label' => 'Запрос котировок',
+            'icon' => 'document-text',
+            'id' => $rfq->id,
+            'title' => $rfq->title,
+            'subtitle' => $rfq->number,
+            'description' => $rfq->description,
+            'url' => route('rfqs.show', $rfq),
+            'status' => $rfq->status,
+        ];
+    }
+
+    /**
+     * Форматирование аукциона
+     */
+    protected function formatAuction(Auction $auction): array
+    {
+        return [
+            'type' => 'auction',
+            'type_label' => 'Аукцион',
+            'icon' => 'currency-dollar',
+            'id' => $auction->id,
+            'title' => $auction->title,
+            'subtitle' => $auction->number,
+            'description' => $auction->description,
+            'url' => route('auctions.show', $auction),
+            'status' => $auction->status,
+        ];
+    }
+}

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -9,16 +9,17 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
+use Laravel\Scout\Searchable;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
-use Orchid\Filters\Filterable; 
+use Orchid\Filters\Filterable;
 use Orchid\Screen\AsSource;
 use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\Activitylog\LogOptions;
 
 class Company extends Model implements HasMedia
 {
-    use HasFactory, SoftDeletes, InteractsWithMedia;
+    use HasFactory, SoftDeletes, InteractsWithMedia, Searchable;
     use AsSource, Filterable, LogsActivity;
 
     protected $fillable = [
@@ -275,5 +276,32 @@ class Company extends Model implements HasMedia
                 'deleted' => 'удалил(а) компанию',
                 default => $eventName,
             });
+    }
+
+    // ========================
+    // ПОИСК (SCOUT)
+    // ========================
+
+    /**
+     * Поля для индексации поиска
+     */
+    public function toSearchableArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'inn' => $this->inn,
+            'short_description' => $this->short_description,
+            'full_description' => $this->full_description,
+        ];
+    }
+
+    /**
+     * Определяет, должна ли модель индексироваться
+     */
+    public function shouldBeSearchable(): bool
+    {
+        // Индексируем только верифицированные компании
+        return $this->is_verified === true;
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
+use Laravel\Scout\Searchable;
 use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\Activitylog\LogOptions;
 use Spatie\MediaLibrary\HasMedia;
@@ -13,7 +14,7 @@ use Spatie\MediaLibrary\InteractsWithMedia;
 
 class Project extends Model
 {
-    use HasFactory, SoftDeletes, LogsActivity;
+    use HasFactory, SoftDeletes, LogsActivity, Searchable;
 
     // ❌ ВРЕМЕННО УБИРАЕМ Spatie Media Library
     // use InteractsWithMedia;
@@ -218,7 +219,7 @@ class Project extends Model
         return 'id'; // по умолчанию и так id, но на случай переопределения
     }
 
-        /**
+    /**
      * Настройки логирования активности
      */
     public function getActivitylogOptions(): LogOptions
@@ -233,5 +234,22 @@ class Project extends Model
                 'deleted' => 'удалил(а) проект',
                 default => $eventName,
             });
+    }
+
+    // ========================
+    // ПОИСК (SCOUT)
+    // ========================
+
+    /**
+     * Поля для индексации поиска
+     */
+    public function toSearchableArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'description' => $this->description,
+            'full_description' => $this->full_description,
+        ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,14 +6,15 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Laravel\Scout\Searchable;
 use Orchid\Filters\Types\Like;
 use Orchid\Filters\Types\Where;
 use Orchid\Filters\Types\WhereDateStartEnd;
 use Orchid\Platform\Models\User as Orchid;
 
-class User extends Orchid 
+class User extends Orchid
 {
-    use HasFactory;
+    use HasFactory, Searchable;
 
     /**
      * The attributes that are mass assignable.
@@ -161,5 +162,23 @@ class User extends Orchid
     public function keywords()
     {
         return $this->hasMany(UserKeyword::class);
+    }
+
+    // ========================
+    // ПОИСК (SCOUT)
+    // ========================
+
+    /**
+     * Поля для индексации поиска
+     */
+    public function toSearchableArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'position' => $this->position,
+            'bio' => $this->bio,
+        ];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "barryvdh/laravel-dompdf": "^3.1",
         "google-gemini-php/client": "^2.6",
         "laravel/framework": "^12.0",
+        "laravel/scout": "*",
         "laravel/socialite": "^5.23",
         "laravel/tinker": "^2.10.1",
         "orchid/platform": "^14.52",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "51fe1abb2aa340a956779bce1061eba4",
+    "content-hash": "35cfabb22b5cc1a584bdfe5256fc25bc",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -10838,5 +10838,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/scout.php
+++ b/config/scout.php
@@ -1,0 +1,210 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Search Engine
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default search connection that gets used while
+    | using Laravel Scout. This connection is used when syncing all models
+    | to the search service. You should adjust this based on your needs.
+    |
+    | Supported: "algolia", "meilisearch", "typesense",
+    |            "database", "collection", "null"
+    |
+    */
+
+    'driver' => env('SCOUT_DRIVER', 'collection'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Index Prefix
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify a prefix that will be applied to all search index
+    | names used by Scout. This prefix may be useful if you have multiple
+    | "tenants" or applications sharing the same search infrastructure.
+    |
+    */
+
+    'prefix' => env('SCOUT_PREFIX', ''),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Queue Data Syncing
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control if the operations that sync your data
+    | with your search engines are queued. When this is set to "true" then
+    | all automatic data syncing will get queued for better performance.
+    |
+    */
+
+    'queue' => env('SCOUT_QUEUE', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Database Transactions
+    |--------------------------------------------------------------------------
+    |
+    | This configuration option determines if your data will only be synced
+    | with your search indexes after every open database transaction has
+    | been committed, thus preventing any discarded data from syncing.
+    |
+    */
+
+    'after_commit' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Chunk Sizes
+    |--------------------------------------------------------------------------
+    |
+    | These options allow you to control the maximum chunk size when you are
+    | mass importing data into the search engine. This allows you to fine
+    | tune each of these chunk sizes based on the power of the servers.
+    |
+    */
+
+    'chunk' => [
+        'searchable' => 500,
+        'unsearchable' => 500,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Soft Deletes
+    |--------------------------------------------------------------------------
+    |
+    | This option allows to control whether to keep soft deleted records in
+    | the search indexes. Maintaining soft deleted records can be useful
+    | if your application still needs to search for the records later.
+    |
+    */
+
+    'soft_delete' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Identify User
+    |--------------------------------------------------------------------------
+    |
+    | This option allows you to control whether to notify the search engine
+    | of the user performing the search. This is sometimes useful if the
+    | engine supports any analytics based on this application's users.
+    |
+    | Supported engines: "algolia"
+    |
+    */
+
+    'identify' => env('SCOUT_IDENTIFY', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Algolia Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Algolia settings. Algolia is a cloud hosted
+    | search engine which works great with Scout out of the box. Just plug
+    | in your application ID and admin API key to get started searching.
+    |
+    */
+
+    'algolia' => [
+        'id' => env('ALGOLIA_APP_ID', ''),
+        'secret' => env('ALGOLIA_SECRET', ''),
+        'index-settings' => [
+            // 'users' => [
+            //     'searchableAttributes' => ['id', 'name', 'email'],
+            //     'attributesForFaceting'=> ['filterOnly(email)'],
+            // ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Meilisearch Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Meilisearch settings. Meilisearch is an open
+    | source search engine with minimal configuration. Below, you can state
+    | the host and key information for your own Meilisearch installation.
+    |
+    | See: https://www.meilisearch.com/docs/learn/configuration/instance_options#all-instance-options
+    |
+    */
+
+    'meilisearch' => [
+        'host' => env('MEILISEARCH_HOST', 'http://localhost:7700'),
+        'key' => env('MEILISEARCH_KEY'),
+        'index-settings' => [
+            // 'users' => [
+            //     'filterableAttributes'=> ['id', 'name', 'email'],
+            // ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Typesense Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Typesense settings. Typesense is an open
+    | source search engine using minimal configuration. Below, you will
+    | state the host, key, and schema configuration for the instance.
+    |
+    */
+
+    'typesense' => [
+        'client-settings' => [
+            'api_key' => env('TYPESENSE_API_KEY', 'xyz'),
+            'nodes' => [
+                [
+                    'host' => env('TYPESENSE_HOST', 'localhost'),
+                    'port' => env('TYPESENSE_PORT', '8108'),
+                    'path' => env('TYPESENSE_PATH', ''),
+                    'protocol' => env('TYPESENSE_PROTOCOL', 'http'),
+                ],
+            ],
+            'nearest_node' => [
+                'host' => env('TYPESENSE_HOST', 'localhost'),
+                'port' => env('TYPESENSE_PORT', '8108'),
+                'path' => env('TYPESENSE_PATH', ''),
+                'protocol' => env('TYPESENSE_PROTOCOL', 'http'),
+            ],
+            'connection_timeout_seconds' => env('TYPESENSE_CONNECTION_TIMEOUT_SECONDS', 2),
+            'healthcheck_interval_seconds' => env('TYPESENSE_HEALTHCHECK_INTERVAL_SECONDS', 30),
+            'num_retries' => env('TYPESENSE_NUM_RETRIES', 3),
+            'retry_interval_seconds' => env('TYPESENSE_RETRY_INTERVAL_SECONDS', 1),
+        ],
+        // 'max_total_results' => env('TYPESENSE_MAX_TOTAL_RESULTS', 1000),
+        'model-settings' => [
+            // User::class => [
+            //     'collection-schema' => [
+            //         'fields' => [
+            //             [
+            //                 'name' => 'id',
+            //                 'type' => 'string',
+            //             ],
+            //             [
+            //                 'name' => 'name',
+            //                 'type' => 'string',
+            //             ],
+            //             [
+            //                 'name' => 'created_at',
+            //                 'type' => 'int64',
+            //             ],
+            //         ],
+            //         'default_sorting_field' => 'created_at',
+            //     ],
+            //     'search-parameters' => [
+            //         'query_by' => 'name'
+            //     ],
+            // ],
+        ],
+        'import_action' => env('TYPESENSE_IMPORT_ACTION', 'upsert'),
+    ],
+
+];

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -126,6 +126,63 @@
 
             <!-- Settings Dropdown (Desktop) -->
             <div class="hidden sm:flex sm:items-center sm:ms-6">
+                <!-- Global Search -->
+                <div class="relative mr-4" x-data="{ open: false, query: '', results: [], loading: false }">
+                    <div class="relative">
+                        <input
+                            type="text"
+                            x-model="query"
+                            @input.debounce.300ms="if(query.length >= 2) { loading = true; fetch('{{ route('search.quick') }}?q=' + encodeURIComponent(query)).then(r => r.json()).then(d => { results = d.results || []; loading = false; open = true; }).catch(() => loading = false); } else { results = []; open = false; }"
+                            @focus="if(results.length > 0) open = true"
+                            @keydown.escape="open = false"
+                            placeholder="Поиск..."
+                            class="w-48 lg:w-64 pl-9 pr-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+                        >
+                        <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                            <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                            </svg>
+                        </div>
+                        <div x-show="loading" class="absolute inset-y-0 right-0 pr-3 flex items-center">
+                            <svg class="animate-spin h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                            </svg>
+                        </div>
+                    </div>
+
+                    <!-- Search Results Dropdown -->
+                    <div
+                        x-show="open && results.length > 0"
+                        @click.away="open = false"
+                        x-transition:enter="transition ease-out duration-100"
+                        x-transition:enter-start="transform opacity-0 scale-95"
+                        x-transition:enter-end="transform opacity-100 scale-100"
+                        x-transition:leave="transition ease-in duration-75"
+                        x-transition:leave-start="transform opacity-100 scale-100"
+                        x-transition:leave-end="transform opacity-0 scale-95"
+                        class="absolute right-0 mt-2 w-80 bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 z-50"
+                        style="display: none;"
+                    >
+                        <div class="py-2 max-h-96 overflow-y-auto">
+                            <template x-for="result in results" :key="result.type + '-' + result.id">
+                                <a :href="result.url" class="flex items-center px-4 py-2 hover:bg-gray-100">
+                                    <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-gray-100 text-gray-600 mr-3 text-xs font-medium" x-text="result.type_label.substring(0, 1)"></span>
+                                    <div class="flex-1 min-w-0">
+                                        <p class="text-sm font-medium text-gray-900 truncate" x-text="result.title"></p>
+                                        <p class="text-xs text-gray-500 truncate" x-text="result.subtitle || result.type_label"></p>
+                                    </div>
+                                </a>
+                            </template>
+                        </div>
+                        <div class="px-4 py-2 border-t border-gray-100 bg-gray-50">
+                            <a :href="'{{ route('search.index') }}?q=' + encodeURIComponent(query)" class="block text-center text-sm text-indigo-600 hover:text-indigo-800">
+                                {{ __('Все результаты') }}
+                            </a>
+                        </div>
+                    </div>
+                </div>
+
                 @auth
                     <!-- Notifications Bell -->
                     <div class="relative mr-4" x-data="{ open: false, notifications: [], loading: false }">

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -1,0 +1,211 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Поиск') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <!-- Форма поиска -->
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg mb-6">
+                <div class="p-6">
+                    <form action="{{ route('search.index') }}" method="GET" class="flex gap-4">
+                        <div class="flex-1">
+                            <input
+                                type="text"
+                                name="q"
+                                value="{{ $query }}"
+                                placeholder="Поиск по компаниям, проектам, тендерам..."
+                                class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                autofocus
+                            >
+                        </div>
+                        <button
+                            type="submit"
+                            class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:bg-indigo-700 active:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150"
+                        >
+                            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                            </svg>
+                            Найти
+                        </button>
+                    </form>
+                </div>
+            </div>
+
+            @if(strlen($query) >= 2)
+                <div class="grid grid-cols-1 lg:grid-cols-4 gap-6">
+                    <!-- Боковая панель: Фильтры -->
+                    <div class="lg:col-span-1">
+                        <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                            <div class="p-4">
+                                <h3 class="font-semibold text-gray-900 mb-4">Тип</h3>
+                                <nav class="space-y-1">
+                                    <a href="{{ route('search.index', ['q' => $query, 'type' => 'all']) }}"
+                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'all' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
+                                        <span>Все результаты</span>
+                                        <span class="text-xs {{ $type === 'all' ? 'text-indigo-600' : 'text-gray-400' }}">
+                                            {{ $counts['users'] + $counts['companies'] + $counts['projects'] + $counts['rfqs'] + $counts['auctions'] }}
+                                        </span>
+                                    </a>
+                                    <a href="{{ route('search.index', ['q' => $query, 'type' => 'companies']) }}"
+                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'companies' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
+                                        <span>Компании</span>
+                                        <span class="text-xs {{ $type === 'companies' ? 'text-indigo-600' : 'text-gray-400' }}">{{ $counts['companies'] }}</span>
+                                    </a>
+                                    <a href="{{ route('search.index', ['q' => $query, 'type' => 'projects']) }}"
+                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'projects' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
+                                        <span>Проекты</span>
+                                        <span class="text-xs {{ $type === 'projects' ? 'text-indigo-600' : 'text-gray-400' }}">{{ $counts['projects'] }}</span>
+                                    </a>
+                                    <a href="{{ route('search.index', ['q' => $query, 'type' => 'rfqs']) }}"
+                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'rfqs' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
+                                        <span>Запросы котировок</span>
+                                        <span class="text-xs {{ $type === 'rfqs' ? 'text-indigo-600' : 'text-gray-400' }}">{{ $counts['rfqs'] }}</span>
+                                    </a>
+                                    <a href="{{ route('search.index', ['q' => $query, 'type' => 'auctions']) }}"
+                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'auctions' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
+                                        <span>Аукционы</span>
+                                        <span class="text-xs {{ $type === 'auctions' ? 'text-indigo-600' : 'text-gray-400' }}">{{ $counts['auctions'] }}</span>
+                                    </a>
+                                    <a href="{{ route('search.index', ['q' => $query, 'type' => 'users']) }}"
+                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'users' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
+                                        <span>Пользователи</span>
+                                        <span class="text-xs {{ $type === 'users' ? 'text-indigo-600' : 'text-gray-400' }}">{{ $counts['users'] }}</span>
+                                    </a>
+                                </nav>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Основная колонка: Результаты -->
+                    <div class="lg:col-span-3">
+                        <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                            <div class="p-6">
+                                @if($results->isEmpty())
+                                    <div class="text-center py-12">
+                                        <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                        </svg>
+                                        <h3 class="mt-2 text-sm font-medium text-gray-900">Ничего не найдено</h3>
+                                        <p class="mt-1 text-sm text-gray-500">
+                                            По запросу "{{ $query }}" ничего не найдено. Попробуйте изменить запрос.
+                                        </p>
+                                    </div>
+                                @else
+                                    <div class="mb-4">
+                                        <p class="text-sm text-gray-500">
+                                            Найдено результатов: {{ $results->count() }}
+                                        </p>
+                                    </div>
+
+                                    <div class="space-y-4">
+                                        @foreach($results as $result)
+                                            <a href="{{ $result['url'] }}" class="block p-4 rounded-lg border border-gray-200 hover:border-indigo-300 hover:bg-indigo-50 transition-colors duration-150">
+                                                <div class="flex items-start gap-4">
+                                                    <!-- Иконка типа -->
+                                                    <div class="flex-shrink-0">
+                                                        @switch($result['type'])
+                                                            @case('user')
+                                                                <div class="w-10 h-10 rounded-full bg-purple-100 flex items-center justify-center">
+                                                                    <svg class="w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"></path>
+                                                                    </svg>
+                                                                </div>
+                                                                @break
+                                                            @case('company')
+                                                                <div class="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center">
+                                                                    <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
+                                                                    </svg>
+                                                                </div>
+                                                                @break
+                                                            @case('project')
+                                                                <div class="w-10 h-10 rounded-full bg-green-100 flex items-center justify-center">
+                                                                    <svg class="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"></path>
+                                                                    </svg>
+                                                                </div>
+                                                                @break
+                                                            @case('rfq')
+                                                                <div class="w-10 h-10 rounded-full bg-yellow-100 flex items-center justify-center">
+                                                                    <svg class="w-5 h-5 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                                                                    </svg>
+                                                                </div>
+                                                                @break
+                                                            @case('auction')
+                                                                <div class="w-10 h-10 rounded-full bg-red-100 flex items-center justify-center">
+                                                                    <svg class="w-5 h-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                                                    </svg>
+                                                                </div>
+                                                                @break
+                                                        @endswitch
+                                                    </div>
+
+                                                    <!-- Контент -->
+                                                    <div class="flex-1 min-w-0">
+                                                        <div class="flex items-center gap-2">
+                                                            <h4 class="text-sm font-medium text-gray-900 truncate">
+                                                                {{ $result['title'] }}
+                                                            </h4>
+                                                            @if(isset($result['is_verified']) && $result['is_verified'])
+                                                                <svg class="w-4 h-4 text-blue-500" fill="currentColor" viewBox="0 0 20 20">
+                                                                    <path fill-rule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
+                                                                </svg>
+                                                            @endif
+                                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600">
+                                                                {{ $result['type_label'] }}
+                                                            </span>
+                                                        </div>
+                                                        @if(isset($result['subtitle']) && $result['subtitle'])
+                                                            <p class="text-sm text-gray-500 truncate">
+                                                                {{ $result['subtitle'] }}
+                                                            </p>
+                                                        @endif
+                                                        @if(isset($result['description']) && $result['description'])
+                                                            <p class="mt-1 text-sm text-gray-600 line-clamp-2">
+                                                                {{ Str::limit($result['description'], 150) }}
+                                                            </p>
+                                                        @endif
+                                                    </div>
+
+                                                    <!-- Стрелка -->
+                                                    <div class="flex-shrink-0">
+                                                        <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                        </svg>
+                                                    </div>
+                                                </div>
+                                            </a>
+                                        @endforeach
+                                    </div>
+                                @endif
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            @elseif(strlen($query) > 0 && strlen($query) < 2)
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-6 text-center">
+                        <p class="text-gray-500">Введите минимум 2 символа для поиска</p>
+                    </div>
+                </div>
+            @else
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                    <div class="p-12 text-center">
+                        <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                        </svg>
+                        <h3 class="mt-2 text-sm font-medium text-gray-900">Глобальный поиск</h3>
+                        <p class="mt-1 text-sm text-gray-500">
+                            Ищите компании, проекты, тендеры и аукционы по названию, описанию или номеру
+                        </p>
+                    </div>
+                </div>
+            @endif
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -217,6 +217,15 @@ Route::middleware('auth')->group(function () {
 });
 
 // ========================================================================
+// SEARCH ROUTES
+// ========================================================================
+
+use App\Http\Controllers\SearchController;
+
+Route::get('/search', [SearchController::class, 'index'])->name('search.index');
+Route::get('/search/quick', [SearchController::class, 'quick'])->name('search.quick');
+
+// ========================================================================
 // AUTH ROUTES
 // ========================================================================
 


### PR DESCRIPTION
### Что сделано? (feat(search))

Внедрён базовый полнотекстовый поиск через **Laravel Scout** с **database-драйвером** (для MVP без внешних сервисов).

**Основные изменения:**
- Установлен пакет `laravel/scout`
- Опубликован и настроен `config/scout.php` → `driver: database`
- Добавлен трейт `Searchable` и метод `toSearchableArray()` в модели:
  - `App\Models\User`
  - `App\Models\Company`
  - `App\Models\Project`
  - `App\Models\Rfq`
  - `App\Models\Auction`
- Выбраны релевантные поля для индексации (name, description, city и т.п.)
- Приведён пример поиска (объединённый по всем моделям или по отдельности)
- Добавлены команды импорта существующих данных: `php artisan scout:import "App\Models\..."`

**Почему database-драйвер для MVP?**
- Нет внешних зависимостей (Meilisearch/Typesense/Algolia)
- Работает на существующей MySQL/PostgreSQL
- LIKE-поиск по нескольким полям — достаточно для старта
- Легко мигрировать на более мощный драйвер позже (код почти не меняется)

**Что проверять после деплоя:**
1. Выполнить импорт индекса для всех моделей:
   ```bash
   php artisan scout:import "App\Models\User"
   # ... и для остальных