### PR TITLE
feat: Production deployment setup with Scheduler

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -31,3 +31,14 @@ redirect_stderr=true
 stdout_logfile=/var/log/queue-worker.log
 stderr_logfile=/var/log/queue-worker.log
 stdout_logfile_maxbytes=50MB
+
+[program:laravel-scheduler]
+command=/bin/sh -c "while true; do php /var/www/artisan schedule:run --verbose --no-interaction; sleep 60; done"
+autostart=true
+autorestart=true
+user=www-data
+numprocs=1
+redirect_stderr=true
+stdout_logfile=/var/log/scheduler.log
+stderr_logfile=/var/log/scheduler.log
+stdout_logfile_maxbytes=50MB

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -287,3 +287,27 @@ SESSION_SECURE_COOKIE=true
 - `CLAUDE.md` — обновлён статус (8/10 спринтов, 80% MVP), добавлен `laravel/scout` в пакеты
 - `docs/README.md` — добавлен спринт 8, обновлён статус, следующий спринт 9
 - `docs/claude/start_message.md` — полностью переписан для спринта 9 (Тестирование + Багфиксы)
+
+---
+
+## 02.02.2026
+
+### Production Deployment — Настройка сервера
+
+**Что сделано:**
+
+1. **Добавлен Laravel Scheduler в Supervisor**
+   - Добавлена программа `laravel-scheduler` в `docker/supervisord.conf`
+   - Scheduler запускает `php artisan schedule:run` каждые 60 секунд
+   - Логи пишутся в `/var/log/scheduler.log`
+
+2. **Документация Production Deployment**
+   - Добавлена секция "Production Deployment" в `CLAUDE.md`
+   - Команды для деплоя через git pull
+   - Все server-команды в формате `docker compose exec app`
+   - Описание auto-start сервисов через Supervisor
+   - First-time setup инструкции
+
+**Изменённые файлы:**
+- `docker/supervisord.conf` — добавлен laravel-scheduler
+- `CLAUDE.md` — добавлена секция Production Deployment


### PR DESCRIPTION
## Summary
- Add Laravel Scheduler to Supervisor (runs `schedule:run` every 60 seconds)
- Add comprehensive Production Deployment section to CLAUDE.md
- Document all server commands in `docker compose exec app` format

## Changes
- `docker/supervisord.conf` — added `laravel-scheduler` program
- `CLAUDE.md` — added Production Deployment section with:
  - Deploy from Git workflow
  - Server commands reference
  - Supervisor auto-start services list
  - First-time setup instructions

## What Supervisor now auto-starts
| Service | Description |
|---------|-------------|
| php-fpm | PHP FastCGI Process Manager |
| nginx | Web server |
| laravel-worker | Queue worker (`queue:work database`) |
| laravel-scheduler | Cron scheduler (`schedule:run` every 60s) |

## Test plan
- [ ] Deploy to server with `git pull`
- [ ] Verify scheduler runs: `docker compose exec app tail -f /var/log/scheduler.log`
- [ ] Verify queues work: `docker compose exec app php artisan queue:restart`

🤖 Generated with [Claude Code](https://claude.com/claude-code)