### PR TITLE
feat: Rebrand to green color scheme

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -84,7 +84,7 @@ html {
 }
 
 .nav-link:hover {
-    color: #5081ff;
+    color: #34d399;
 }
 
 /* Мобильный toggle */
@@ -156,10 +156,10 @@ html {
 .features-block {
     flex: 1;
     padding: 50px 40px;
-    background: #4169E1;
+    background: linear-gradient(135deg, #28a745 0%, #81b407 100%);
     color: white;
-    display: flex;  
-    flex-direction: column;  
+    display: flex;
+    flex-direction: column;
     justify-content: center;
 }
 
@@ -191,7 +191,7 @@ html {
 .feature-icon svg {
     width: 35px;
     height: 35px;
-    fill: #2A5BDD;
+    fill: #28a745;
 }
 
 .feature-info h4 {
@@ -264,7 +264,7 @@ html {
 
 .form-control:focus {
     outline: none;
-    border-color: #2A5BDD;
+    border-color: #28a745;
 }
 
 /* Форма опций */
@@ -288,7 +288,7 @@ html {
 }
 
 .form-options a {
-    color: #2A5BDD;
+    color: #28a745;
     text-decoration: none;
     font-weight: 500;
 }
@@ -297,7 +297,7 @@ html {
 .btn-login {
     width: 100%;
     padding: 15px;
-    background: #2A5BDD;
+    background: linear-gradient(135deg, #28a745 0%, #81b407 100%);
     border: none;
     border-radius: 12px;
     color: white;
@@ -308,7 +308,7 @@ html {
 }
 
 .btn-login:hover {
-    background: #1d4bbd;
+    background: linear-gradient(135deg, #22963e 0%, #6b9a06 100%);
     transform: translateY(-2px);
 }
 
@@ -323,7 +323,7 @@ html {
 }
 
 .register-link a {
-    color: #2A5BDD;
+    color: #28a745;
     font-weight: 600;
     text-decoration: none;
     font-size: 1rem;

--- a/resources/views/auctions/create.blade.php
+++ b/resources/views/auctions/create.blade.php
@@ -26,7 +26,7 @@
                         <select name="company_id" 
                                 id="company_id" 
                                 required
-                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('company_id') border-red-500 @enderror">
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('company_id') border-red-500 @enderror">
                             <option value="">Выберите компанию...</option>
                             @foreach($companies as $company)
                                 <option value="{{ $company->id }}" {{ old('company_id') == $company->id ? 'selected' : '' }}>
@@ -50,7 +50,7 @@
                                required
                                value="{{ old('title') }}"
                                placeholder="Например: Поставка офисной мебели"
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('title') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('title') border-red-500 @enderror">
                         @error('title')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -65,7 +65,7 @@
                                   id="description" 
                                   rows="5"
                                   placeholder="Подробное описание предмета аукциона, требований и условий..."
-                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('description') border-red-500 @enderror">{{ old('description') }}</textarea>
+                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('description') border-red-500 @enderror">{{ old('description') }}</textarea>
                         @error('description')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -83,7 +83,7 @@
                                        value="open" 
                                        {{ old('type', 'open') === 'open' ? 'checked' : '' }}
                                        onchange="toggleInvitations()"
-                                       class="rounded-full border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                       class="rounded-full border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <span class="ml-2 text-sm text-gray-700">
                                     Открытая процедура 
                                     <span class="text-gray-500">(любая компания может подать заявку)</span>
@@ -96,7 +96,7 @@
                                        value="closed" 
                                        {{ old('type') === 'closed' ? 'checked' : '' }}
                                        onchange="toggleInvitations()"
-                                       class="rounded-full border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                       class="rounded-full border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <span class="ml-2 text-sm text-gray-700">
                                     Закрытая процедура 
                                     <span class="text-gray-500">(только приглашённые компании)</span>
@@ -117,7 +117,7 @@
                                 id="invited_companies" 
                                 multiple
                                 size="10"
-                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                             @foreach($allCompanies as $company)
                                 <option value="{{ $company->id }}" {{ in_array($company->id, old('invited_companies', [])) ? 'selected' : '' }}>
                                     {{ $company->name }} (ИНН: {{ $company->inn }})
@@ -142,7 +142,7 @@
                                    id="start_date"
                                    required
                                    value="{{ old('start_date', now()->addDay()->format('Y-m-d\TH:i')) }}"
-                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('start_date') border-red-500 @enderror">
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('start_date') border-red-500 @enderror">
                             <p class="mt-1 text-xs text-gray-500">UTC +3 (Москва)</p>
                             @error('start_date')
                                 <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -159,7 +159,7 @@
                                    id="end_date"
                                    required
                                    value="{{ old('end_date', now()->addWeek()->format('Y-m-d\TH:i')) }}"
-                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('end_date') border-red-500 @enderror">
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('end_date') border-red-500 @enderror">
                             <p class="mt-1 text-xs text-gray-500">UTC +3 (Москва)</p>
                             @error('end_date')
                                 <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -177,7 +177,7 @@
                                id="trading_start" 
                                required
                                value="{{ old('trading_start', now()->addWeek()->addDay()->format('Y-m-d\TH:i')) }}"
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('trading_start') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('trading_start') border-red-500 @enderror">
                         <p class="mt-1 text-sm text-gray-500">Время указывается по UTC +3 (Москва)</p>
                         @error('trading_start')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -197,7 +197,7 @@
                                required
                                value="{{ old('starting_price') }}"
                                placeholder="Введите начальную максимальную цену"
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('starting_price') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('starting_price') border-red-500 @enderror">
                         <p class="mt-1 text-sm text-gray-500">Участники смогут снижать цену на 0.5% — 5% от текущей</p>
                         @error('starting_price')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -233,7 +233,7 @@
                                        value="draft" 
                                        {{ old('status', 'draft') === 'draft' ? 'checked' : '' }}
                                        onchange="toggleStatusWarning()"
-                                       class="rounded-full border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                       class="rounded-full border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <span class="ml-2 text-sm text-gray-700">
                                     Сохранить как черновик
                                     <span class="text-gray-500">(можно будет отредактировать позже)</span>
@@ -246,7 +246,7 @@
                                        value="active" 
                                        {{ old('status') === 'active' ? 'checked' : '' }}
                                        onchange="toggleStatusWarning()"
-                                       class="rounded-full border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                       class="rounded-full border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <span class="ml-2 text-sm text-gray-700">
                                     Опубликовать сразу
                                     <span class="text-gray-500">(начнётся приём заявок)</span>
@@ -282,7 +282,7 @@
                                    name="notification_agreement" 
                                    id="notification_agreement"
                                    required
-                                   class="mt-1 rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                   class="mt-1 rounded border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                             <label for="notification_agreement" class="ml-3 text-sm text-gray-700">
                                 Я уведомлён, что процедура проведения Аукциона не является торгами и не обязывает к заключению договора. 
                                 Результаты подведения итогов носят информационный характер.

--- a/resources/views/auctions/edit.blade.php
+++ b/resources/views/auctions/edit.blade.php
@@ -29,7 +29,7 @@
                                id="title" 
                                required
                                value="{{ old('title', $auction->title) }}"
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('title') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('title') border-red-500 @enderror">
                         @error('title')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -43,7 +43,7 @@
                         <textarea name="description" 
                                   id="description" 
                                   rows="5"
-                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('description') border-red-500 @enderror">{{ old('description', $auction->description) }}</textarea>
+                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('description') border-red-500 @enderror">{{ old('description', $auction->description) }}</textarea>
                         @error('description')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -59,7 +59,7 @@
                                id="end_date" 
                                required
                                value="{{ old('end_date', $auction->end_date->format('Y-m-d\TH:i')) }}"
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('end_date') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('end_date') border-red-500 @enderror">
                         @error('end_date')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -78,7 +78,7 @@
                                id="trading_start" 
                                required
                                value="{{ old('trading_start', $auction->trading_start->format('Y-m-d\TH:i')) }}"
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('trading_start') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('trading_start') border-red-500 @enderror">
                         @error('trading_start')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -99,7 +99,7 @@
                                min="0"
                                required
                                value="{{ old('starting_price', $auction->starting_price) }}"
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('starting_price') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('starting_price') border-red-500 @enderror">
                         <p class="mt-1 text-sm text-gray-500">Участники смогут снижать цену на 0.5% — 5% от текущей</p>
                         @error('starting_price')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -125,7 +125,7 @@
                                 </div>
                                 <a href="{{ $auction->getFirstMediaUrl('technical_specification') }}" 
                                    target="_blank"
-                                   class="text-sm text-indigo-600 hover:text-indigo-500">
+                                   class="text-sm text-emerald-600 hover:text-emerald-500">
                                     Просмотр
                                 </a>
                             </div>
@@ -135,7 +135,7 @@
                                name="technical_specification" 
                                id="technical_specification" 
                                accept="application/pdf"
-                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100 @error('technical_specification') border-red-500 @enderror">
+                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-emerald-50 file:text-emerald-700 hover:file:bg-emerald-100 @error('technical_specification') border-red-500 @enderror">
                         <p class="mt-1 text-sm text-gray-500">Оставьте пустым, если не хотите заменять файл. Максимальный размер: 10 МБ</p>
                         @error('technical_specification')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -149,7 +149,7 @@
                             Отмена
                         </a>
                         <button type="submit" 
-                                class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                             Сохранить изменения
                         </button>
                     </div>

--- a/resources/views/auctions/index.blade.php
+++ b/resources/views/auctions/index.blade.php
@@ -36,13 +36,13 @@
                                name="search" 
                                placeholder="Поиск по названию или номеру..."
                                value="{{ request('search') }}"
-                               class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                               class="w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                     </div>
                     
                     <!-- Статус -->
                     <div>
                         <select name="status" 
-                                class="w-full md:w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                class="w-full md:w-40 rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                             <option value="">Все статусы</option>
                             <option value="draft" {{ request('status') === 'draft' ? 'selected' : '' }}>Черновик</option>
                             <option value="active" {{ request('status') === 'active' ? 'selected' : '' }}>Приём заявок</option>
@@ -54,7 +54,7 @@
                     <!-- Тип -->
                     <div>
                         <select name="type" 
-                                class="w-full md:w-40 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                class="w-full md:w-40 rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                             <option value="">Все типы</option>
                             <option value="open" {{ request('type') === 'open' ? 'selected' : '' }}>Открытая</option>
                             <option value="closed" {{ request('type') === 'closed' ? 'selected' : '' }}>Закрытая</option>
@@ -64,7 +64,7 @@
                     <!-- Кнопки -->
                     <div class="flex gap-2">
                         <button type="submit" 
-                                class="px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                class="px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                             Применить
                         </button>
                         <a href="{{ route('auctions.index') }}" 

--- a/resources/views/auctions/my-auctions.blade.php
+++ b/resources/views/auctions/my-auctions.blade.php
@@ -72,7 +72,7 @@
                                             {{ $auction->number }}
                                         </td>
                                         <td class="px-6 py-4 text-sm text-gray-900">
-                                            <a href="{{ route('auctions.show', $auction) }}" class="text-indigo-600 hover:text-indigo-900">
+                                            <a href="{{ route('auctions.show', $auction) }}" class="text-emerald-600 hover:text-emerald-900">
                                                 {{ Str::limit($auction->title, 40) }}
                                             </a>
                                         </td>
@@ -84,7 +84,7 @@
                                                 $statusColors = [
                                                     'draft' => 'bg-yellow-100 text-yellow-800',
                                                     'active' => 'bg-green-100 text-green-800',
-                                                    'trading' => 'bg-blue-100 text-blue-800',
+                                                    'trading' => 'bg-emerald-100 text-emerald-800',
                                                     'closed' => 'bg-gray-100 text-gray-800',
                                                 ];
                                                 $statusLabels = [
@@ -106,7 +106,7 @@
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                                             <a href="{{ route('auctions.show', $auction) }}" 
-                                               class="text-indigo-600 hover:text-indigo-900">
+                                               class="text-emerald-600 hover:text-emerald-900">
                                                 Просмотр
                                             </a>
                                         </td>

--- a/resources/views/auctions/my-bids.blade.php
+++ b/resources/views/auctions/my-bids.blade.php
@@ -20,7 +20,7 @@
                     </svg>
                     <p class="mt-4 text-gray-500">Вы ещё не подавали заявок на участие в аукционах.</p>
                     <a href="{{ route('auctions.index') }}" 
-                       class="mt-4 inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700">
+                       class="mt-4 inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700">
                         Найти аукционы
                     </a>
                 </div>
@@ -59,7 +59,7 @@
                                 @foreach($bids as $bid)
                                     <tr class="{{ $bid->status === 'winner' ? 'bg-green-50' : '' }}">
                                         <td class="px-6 py-4 text-sm text-gray-900">
-                                            <a href="{{ route('auctions.show', $bid->auction) }}" class="text-indigo-600 hover:text-indigo-900">
+                                            <a href="{{ route('auctions.show', $bid->auction) }}" class="text-emerald-600 hover:text-emerald-900">
                                                 {{ $bid->auction->number }}
                                             </a>
                                             <br>
@@ -70,7 +70,7 @@
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                                             @if($bid->type === 'initial')
-                                                <span class="text-blue-600">Заявка</span>
+                                                <span class="text-emerald-600">Заявка</span>
                                             @else
                                                 <span class="text-purple-600">Ставка</span>
                                             @endif
@@ -89,7 +89,7 @@
                                             @if($bid->status === 'winner')
                                                 <span class="px-2 py-1 text-xs font-semibold rounded-full bg-green-100 text-green-800">Победитель</span>
                                             @elseif($bid->status === 'accepted')
-                                                <span class="px-2 py-1 text-xs font-semibold rounded-full bg-blue-100 text-blue-800">Принята</span>
+                                                <span class="px-2 py-1 text-xs font-semibold rounded-full bg-emerald-100 text-emerald-800">Принята</span>
                                             @else
                                                 <span class="px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-800">Ожидание</span>
                                             @endif
@@ -99,7 +99,7 @@
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
                                             <a href="{{ route('auctions.show', $bid->auction) }}" 
-                                               class="text-indigo-600 hover:text-indigo-900">
+                                               class="text-emerald-600 hover:text-emerald-900">
                                                 Просмотр
                                             </a>
                                         </td>

--- a/resources/views/auctions/my-invitations.blade.php
+++ b/resources/views/auctions/my-invitations.blade.php
@@ -69,7 +69,7 @@
                                             @php
                                                 $statusColors = [
                                                     'active' => 'bg-green-100 text-green-800',
-                                                    'trading' => 'bg-blue-100 text-blue-800',
+                                                    'trading' => 'bg-emerald-100 text-emerald-800',
                                                     'closed' => 'bg-gray-100 text-gray-800',
                                                     'draft' => 'bg-yellow-100 text-yellow-800',
                                                 ];
@@ -89,7 +89,7 @@
                                                 <span class="text-green-600">✓ Заявка подана</span>
                                             @elseif($auction->isAcceptingApplications() || $auction->isTrading())
                                                 <a href="{{ route('auctions.show', $auction) }}#bid-form" 
-                                                   class="text-indigo-600 hover:text-indigo-900">
+                                                   class="text-emerald-600 hover:text-emerald-900">
                                                     Подать заявку
                                                 </a>
                                             @else

--- a/resources/views/auctions/show.blade.php
+++ b/resources/views/auctions/show.blade.php
@@ -33,7 +33,7 @@
                     <!-- Кнопка редактирования (только для черновиков) -->
                     @if($auction->status === 'draft')
                         <a href="{{ route('auctions.edit', $auction) }}" 
-                        class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                        class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
                             </svg>
@@ -89,7 +89,7 @@
                                 }
                             } elseif ($auction->status === 'trading') {
                                 $displayLabel = 'Торги';
-                                $displayColor = 'bg-blue-100 text-blue-800';
+                                $displayColor = 'bg-emerald-100 text-emerald-800';
                             } elseif ($auction->status === 'closed') {
                                 $displayLabel = 'Завершён';
                                 $displayColor = 'bg-gray-100 text-gray-800';
@@ -106,7 +106,7 @@
                             <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{ $displayColor }}">
                                 {{ $displayLabel }}
                             </span>
-                            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{ $auction->type === 'open' ? 'bg-blue-100 text-blue-800' : 'bg-purple-100 text-purple-800' }}">
+                            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{ $auction->type === 'open' ? 'bg-emerald-100 text-emerald-800' : 'bg-purple-100 text-purple-800' }}">
                                 {{ $auction->type === 'open' ? 'Открытая процедура' : 'Закрытая процедура' }}
                             </span>
                             
@@ -146,7 +146,7 @@
                             <div>
                                 <p class="text-xs text-gray-500">Организатор</p>
                                 <a href="{{ route('companies.show', $auction->company) }}" 
-                                   class="text-base font-semibold text-indigo-600 hover:text-indigo-500">
+                                   class="text-base font-semibold text-emerald-600 hover:text-emerald-500">
                                     {{ $auction->company->name }}
                                 </a>
                             </div>
@@ -193,7 +193,7 @@
                         @if($auction->hasMedia('technical_specification'))
                             <a href="{{ $auction->getFirstMediaUrl('technical_specification') }}" 
                                target="_blank"
-                               class="block w-full text-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition mb-4">
+                               class="block w-full text-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition mb-4">
                                 <svg class="w-4 h-4 inline mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
                                 </svg>
@@ -273,15 +273,15 @@
                         {{-- Левая колонка: Форма ставки --}}
                         <div class="lg:w-1/3">
                             <h3 class="text-lg font-semibold text-gray-900 mb-4 flex items-center">
-                                <svg class="w-5 h-5 mr-2 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <svg class="w-5 h-5 mr-2 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
                                 </svg>
                                 Торги в реальном времени
                             </h3>
 
-                            <div class="bg-blue-50 rounded-lg p-4 mb-4">
+                            <div class="bg-emerald-50 rounded-lg p-4 mb-4">
                                 <p class="text-sm text-gray-600">Текущая цена:</p>
-                                <p class="text-3xl font-bold text-blue-600 current-price">{{ number_format($currentPrice, 2, ',', ' ') }} ₽</p>
+                                <p class="text-3xl font-bold text-emerald-600 current-price">{{ number_format($currentPrice, 2, ',', ' ') }} ₽</p>
                                 @if($auction->last_bid_at)
                                     <p class="text-xs text-gray-500 mt-1">
                                         Последняя ставка: {{ $auction->last_bid_at->format('H:i:s') }}
@@ -294,7 +294,7 @@
                                     <form method="POST" action="{{ route('auctions.bids.store', $auction) }}" class="space-y-4">
                                         @csrf
                                         @if($userCompanies->count() > 1)
-                                            <select name="company_id" required class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 text-sm">
+                                            <select name="company_id" required class="w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-blue-500 text-sm">
                                                 <option value="">Выберите компанию...</option>
                                                 @foreach($userCompanies as $company)
                                                     <option value="{{ $company->id }}">{{ $company->name }}</option>
@@ -311,7 +311,7 @@
                                                 @foreach($percentages as $pct)
                                                     @php $newPrice = round($currentPrice * (1 - $pct / 100), 2); @endphp
                                                     <button type="button" onclick="setMainBidPrice({{ $newPrice }})"
-                                                            class="main-bid-btn px-2 py-1 text-xs font-medium rounded border border-gray-300 bg-white text-gray-700 hover:bg-blue-50 hover:border-blue-500 transition">
+                                                            class="main-bid-btn px-2 py-1 text-xs font-medium rounded border border-gray-300 bg-white text-gray-700 hover:bg-emerald-50 hover:border-emerald-500 transition">
                                                         -{{ $pct }}%
                                                     </button>
                                                 @endforeach
@@ -321,14 +321,14 @@
                                         <input type="number" name="price" id="main-price" step="0.01"
                                                min="{{ $currentPrice - $stepRange['max'] }}" max="{{ $currentPrice - $stepRange['min'] }}"
                                                required placeholder="Ваша ставка (₽)"
-                                               class="w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                                               class="w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-blue-500">
 
                                         <label class="flex items-start text-xs text-gray-600">
                                             <input type="checkbox" name="acknowledgement" required class="mt-0.5 mr-2 rounded border-gray-300">
                                             Подтверждаю условия участия
                                         </label>
 
-                                        <button type="submit" class="w-full px-4 py-2 bg-blue-600 text-white text-sm font-semibold rounded-md hover:bg-blue-700 transition">
+                                        <button type="submit" class="w-full px-4 py-2 bg-emerald-600 text-white text-sm font-semibold rounded-md hover:bg-emerald-700 transition">
                                             Сделать ставку
                                         </button>
                                     </form>
@@ -340,7 +340,7 @@
                             @else
                                 <div class="bg-gray-50 rounded-lg p-4 text-center">
                                     <p class="text-sm text-gray-600">
-                                        <a href="{{ route('login') }}" class="text-blue-600 hover:underline">Войдите</a>, чтобы участвовать
+                                        <a href="{{ route('login') }}" class="text-emerald-600 hover:underline">Войдите</a>, чтобы участвовать
                                     </p>
                                 </div>
                             @endauth
@@ -367,8 +367,8 @@
                                             @php $userCompanyIds = auth()->check() ? $userCompanies->pluck('id')->toArray() : []; @endphp
                                             @foreach($auction->tradingBids->take(20) as $bid)
                                                 @php $isUserBid = in_array($bid->company_id, $userCompanyIds); @endphp
-                                                <tr class="{{ $isUserBid ? 'bg-blue-50' : '' }}">
-                                                    <td class="px-4 py-2 whitespace-nowrap text-sm {{ $isUserBid ? 'text-blue-600 font-medium' : 'text-gray-900' }}">
+                                                <tr class="{{ $isUserBid ? 'bg-emerald-50' : '' }}">
+                                                    <td class="px-4 py-2 whitespace-nowrap text-sm {{ $isUserBid ? 'text-emerald-600 font-medium' : 'text-gray-900' }}">
                                                         {{ $bid->anonymous_code }}
                                                         @if($isUserBid) <span class="text-xs">(вы)</span> @endif
                                                     </td>
@@ -401,7 +401,7 @@
                 <nav class="-mb-px flex space-x-8 px-6" aria-label="Tabs">
                     <button onclick="showTab('description')" 
                             id="tab-description"
-                            class="tab-button active border-indigo-500 text-indigo-600 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
+                            class="tab-button active border-emerald-500 text-emerald-600 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
                         Описание
                     </button>
                     <button onclick="showTab('bids')" 
@@ -567,12 +567,12 @@
                                 </form>
                             </div>
                         @elseif($existingBid)
-                            <div class="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-6">
+                            <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-6 mb-6">
                                 <div class="flex items-center">
-                                    <svg class="w-6 h-6 text-blue-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <svg class="w-6 h-6 text-emerald-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                                     </svg>
-                                    <p class="text-blue-800 font-medium">Вы уже подали заявку на этот аукцион</p>
+                                    <p class="text-emerald-800 font-medium">Вы уже подали заявку на этот аукцион</p>
                                 </div>
                             </div>
                         @elseif($auction->status === 'draft')
@@ -621,21 +621,21 @@
                                 </div>
                             </div>
                         @elseif($userCompanies->isEmpty())
-                            <div class="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-6">
+                            <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-6 mb-6">
                                 <div class="flex items-center">
-                                    <svg class="w-6 h-6 text-blue-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <svg class="w-6 h-6 text-emerald-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
                                     </svg>
-                                    <p class="text-blue-800">Для подачи заявки необходимо быть модератором компании. <a href="{{ route('companies.create') }}" class="underline font-semibold">Создайте компанию</a> или получите права модератора.</p>
+                                    <p class="text-emerald-800">Для подачи заявки необходимо быть модератором компании. <a href="{{ route('companies.create') }}" class="underline font-semibold">Создайте компанию</a> или получите права модератора.</p>
                                 </div>
                             </div>
                         @endif
                     @else
-                        <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6 text-center">
+                        <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-4 mb-6 text-center">
                             <p class="text-gray-700">
-                                <a href="{{ route('login') }}" class="text-indigo-600 hover:text-indigo-500 font-semibold">Войдите</a> 
+                                <a href="{{ route('login') }}" class="text-emerald-600 hover:text-emerald-500 font-semibold">Войдите</a> 
                                 или 
-                                <a href="{{ route('register') }}" class="text-indigo-600 hover:text-indigo-500 font-semibold">зарегистрируйтесь</a>, 
+                                <a href="{{ route('register') }}" class="text-emerald-600 hover:text-emerald-500 font-semibold">зарегистрируйтесь</a>, 
                                 чтобы подать заявку
                             </p>
                         </div>
@@ -681,14 +681,14 @@
                                         @php
                                             $isUserBid = in_array($bid->company_id, $userCompanyIds);
                                         @endphp
-                                        <tr class="{{ $bid->status === 'winner' ? 'bg-green-50' : ($isUserBid ? 'bg-blue-50' : '') }}">
+                                        <tr class="{{ $bid->status === 'winner' ? 'bg-green-50' : ($isUserBid ? 'bg-emerald-50' : '') }}">
                                             @if($auction->isTrading())
                                                 <td class="px-6 py-4 whitespace-nowrap">
                                                     {{-- A10: Скрываем названия компаний от всех (включая организатора) до завершения аукциона --}}
-                                                    <span class="text-sm font-medium {{ $isUserBid ? 'text-blue-600' : 'text-gray-900' }}">
+                                                    <span class="text-sm font-medium {{ $isUserBid ? 'text-emerald-600' : 'text-gray-900' }}">
                                                         {{ $bid->anonymous_code }}
                                                         @if($isUserBid)
-                                                            <span class="ml-1 text-xs text-blue-500">(вы)</span>
+                                                            <span class="ml-1 text-xs text-emerald-500">(вы)</span>
                                                         @endif
                                                     </span>
                                                 </td>
@@ -703,20 +703,20 @@
                                                 <td class="px-6 py-4 whitespace-nowrap">
                                                     @if($auction->status === 'closed')
                                                         {{-- После закрытия показываем названия компаний --}}
-                                                        <a href="{{ route('companies.show', $bid->company) }}" class="text-sm font-medium text-indigo-600 hover:text-indigo-500">
+                                                        <a href="{{ route('companies.show', $bid->company) }}" class="text-sm font-medium text-emerald-600 hover:text-emerald-500">
                                                             {{ $bid->company->name }}
                                                         </a>
                                                     @else
                                                         {{-- A10: На этапе приёма заявок скрываем названия от всех, кроме организатора --}}
                                                         @if($auction->canManage(auth()->user()))
-                                                            <a href="{{ route('companies.show', $bid->company) }}" class="text-sm font-medium text-indigo-600 hover:text-indigo-500">
+                                                            <a href="{{ route('companies.show', $bid->company) }}" class="text-sm font-medium text-emerald-600 hover:text-emerald-500">
                                                                 {{ $bid->company->name }}
                                                             </a>
                                                         @else
-                                                            <span class="text-sm font-medium {{ $isUserBid ? 'text-blue-600' : 'text-gray-900' }}">
+                                                            <span class="text-sm font-medium {{ $isUserBid ? 'text-emerald-600' : 'text-gray-900' }}">
                                                                 Участник {{ $loop->iteration }}
                                                                 @if($isUserBid)
-                                                                    <span class="ml-1 text-xs text-blue-500">(вы)</span>
+                                                                    <span class="ml-1 text-xs text-emerald-500">(вы)</span>
                                                                 @endif
                                                             </span>
                                                         @endif
@@ -766,7 +766,7 @@
                                             @endif
                                             <div>
                                                 <a href="{{ route('companies.show', $invitation->company) }}" 
-                                                   class="text-sm font-medium text-indigo-600 hover:text-indigo-500">
+                                                   class="text-sm font-medium text-emerald-600 hover:text-emerald-500">
                                                     {{ $invitation->company->name }}
                                                 </a>
                                                 <p class="text-xs text-gray-500">
@@ -820,9 +820,9 @@
             priceInput.value = price.toFixed(2);
             // Подсветка выбранной кнопки
             document.querySelectorAll('.main-bid-btn').forEach(btn => {
-                btn.classList.remove('bg-blue-100', 'border-blue-500', 'text-blue-700');
+                btn.classList.remove('bg-emerald-100', 'border-emerald-500', 'text-emerald-700');
             });
-            event.target.classList.add('bg-blue-100', 'border-blue-500', 'text-blue-700');
+            event.target.classList.add('bg-emerald-100', 'border-emerald-500', 'text-emerald-700');
         }
     }
 
@@ -835,7 +835,7 @@
         
         // Убираем активный класс у всех кнопок
         document.querySelectorAll('.tab-button').forEach(button => {
-            button.classList.remove('active', 'border-indigo-500', 'text-indigo-600');
+            button.classList.remove('active', 'border-emerald-500', 'text-emerald-600');
             button.classList.add('border-transparent', 'text-gray-500');
         });
         
@@ -845,7 +845,7 @@
         // Активируем кнопку
         const activeButton = document.getElementById('tab-' + tabName);
         activeButton.classList.remove('border-transparent', 'text-gray-500');
-        activeButton.classList.add('active', 'border-indigo-500', 'text-indigo-600');
+        activeButton.classList.add('active', 'border-emerald-500', 'text-emerald-600');
     }
 
     @if($auction->isTrading())

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -27,14 +27,14 @@
         <!-- Remember Me -->
         <div class="block mt-4">
             <label for="remember_me" class="inline-flex items-center">
-                <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-indigo-600 shadow-sm focus:ring-indigo-500" name="remember">
+                <input id="remember_me" type="checkbox" class="rounded border-gray-300 text-emerald-600 shadow-sm focus:ring-emerald-500" name="remember">
                 <span class="ms-2 text-sm text-gray-600">{{ __('Remember me') }}</span>
             </label>
         </div>
 
         <div class="flex items-center justify-end mt-4">
             @if (Route::has('password.request'))
-                <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('password.request') }}">
+                <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500" href="{{ route('password.request') }}">
                     {{ __('Forgot your password?') }}
                 </a>
             @endif

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -40,7 +40,7 @@
         </div>
 
         <div class="flex items-center justify-end mt-4">
-            <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('login') }}">
+            <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500" href="{{ route('login') }}">
                 {{ __('Already registered?') }}
             </a>
 

--- a/resources/views/auth/verify-email.blade.php
+++ b/resources/views/auth/verify-email.blade.php
@@ -23,7 +23,7 @@
         <form method="POST" action="{{ route('logout') }}">
             @csrf
 
-            <button type="submit" class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+            <button type="submit" class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">
                 {{ __('Log Out') }}
             </button>
         </form>

--- a/resources/views/companies/create.blade.php
+++ b/resources/views/companies/create.blade.php
@@ -41,7 +41,7 @@
                                id="name" 
                                value="{{ old('name') }}"
                                required
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm @error('name') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm @error('name') border-red-500 @enderror">
                         @error('name')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -60,7 +60,7 @@
                                pattern="[0-9]{10}([0-9]{2})?"
                                required
                                placeholder="1234567890"
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm @error('inn') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm @error('inn') border-red-500 @enderror">
                         <p class="mt-1 text-xs text-gray-500">ИНН: 10 цифр (юрлицо/ИП) или 12 цифр (физлицо)</p>
                         @error('inn')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -74,7 +74,7 @@
                         </label>
                         <select name="legal_form" 
                                 id="legal_form"
-                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm">
                             <option value="">Не выбрано</option>
                             <option value="ООО" {{ old('legal_form') == 'ООО' ? 'selected' : '' }}>ООО</option>
                             <option value="АО" {{ old('legal_form') == 'АО' ? 'selected' : '' }}>АО</option>
@@ -95,7 +95,7 @@
                         </label>
                         <select name="industry_id"
                                 id="industry_id"
-                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base sm:text-sm">
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-base sm:text-sm">
                             <option value="">Не выбрано</option>
                             @foreach($industries as $industry)
                                 <option value="{{ $industry->id }}" {{ old('industry_id') == $industry->id ? 'selected' : '' }}>
@@ -118,7 +118,7 @@
                                   rows="3"
                                   maxlength="500"
                                   placeholder="Кратко опишите деятельность компании (до 500 символов)"
-                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm @error('short_description') border-red-500 @enderror">{{ old('short_description') }}</textarea>
+                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm @error('short_description') border-red-500 @enderror">{{ old('short_description') }}</textarea>
                         <p class="mt-1 text-xs text-gray-500">Максимум 500 символов</p>
                         @error('short_description')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -134,7 +134,7 @@
                                   id="full_description" 
                                   rows="6"
                                   placeholder="Подробное описание компании, её деятельности, достижений и преимуществ"
-                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm @error('full_description') border-red-500 @enderror">{{ old('full_description') }}</textarea>
+                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm @error('full_description') border-red-500 @enderror">{{ old('full_description') }}</textarea>
                         @error('full_description')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -149,7 +149,7 @@
                                name="logo" 
                                id="logo" 
                                accept="image/*"
-                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
+                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-emerald-50 file:text-emerald-700 hover:file:bg-emerald-100">
                         <p class="mt-1 text-xs text-gray-500">Форматы: JPG, PNG. Максимальный размер: 2MB</p>
                         @error('logo')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -166,7 +166,7 @@
                                id="documents" 
                                accept=".pdf"
                                multiple
-                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
+                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-emerald-50 file:text-emerald-700 hover:file:bg-emerald-100">
                         <p class="mt-1 text-xs text-gray-500">Устав, ИНН, ОГРН и другие документы. Максимум 10 файлов по 10MB</p>
                         @error('documents.*')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -176,11 +176,11 @@
                     <!-- Кнопки -->
                     <div class="flex items-center justify-end gap-4 pt-4 border-t">
                         <a href="{{ route('companies.index') }}" 
-                           class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                           class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150">
                             Отмена
                         </a>
                         <button type="submit" 
-                                class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 active:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                                class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 active:bg-emerald-900 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150">
                             Создать компанию
                         </button>
                     </div>

--- a/resources/views/companies/edit.blade.php
+++ b/resources/views/companies/edit.blade.php
@@ -52,7 +52,7 @@
                                id="name" 
                                value="{{ old('name', $company->name) }}"
                                required
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm @error('name') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm @error('name') border-red-500 @enderror">
                         @error('name')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -71,7 +71,7 @@
                                pattern="[0-9]{10}([0-9]{2})?"
                                required
                                placeholder="1234567890"
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm @error('inn') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm @error('inn') border-red-500 @enderror">
                         <p class="mt-1 text-xs text-gray-500">ИНН: 10 цифр (юрлицо/ИП) или 12 цифр (физлицо)</p>
                         @error('inn')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -85,7 +85,7 @@
                         </label>
                         <select name="legal_form" 
                                 id="legal_form"
-                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm">
                             <option value="">Не выбрано</option>
                             <option value="ООО" {{ old('legal_form', $company->legal_form) == 'ООО' ? 'selected' : '' }}>ООО</option>
                             <option value="АО" {{ old('legal_form', $company->legal_form) == 'АО' ? 'selected' : '' }}>АО</option>
@@ -106,7 +106,7 @@
                         </label>
                         <select name="industry_id"
                                 id="industry_id"
-                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-base sm:text-sm">
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-base sm:text-sm">
                             <option value="">Не выбрано</option>
                             @foreach($industries as $industry)
                                 <option value="{{ $industry->id }}" {{ old('industry_id', $company->industry_id) == $industry->id ? 'selected' : '' }}>
@@ -129,7 +129,7 @@
                                   rows="3"
                                   maxlength="500"
                                   placeholder="Кратко опишите деятельность компании (до 500 символов)"
-                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm @error('short_description') border-red-500 @enderror">{{ old('short_description', $company->short_description) }}</textarea>
+                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm @error('short_description') border-red-500 @enderror">{{ old('short_description', $company->short_description) }}</textarea>
                         <p class="mt-1 text-xs text-gray-500">Максимум 500 символов</p>
                         @error('short_description')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -145,7 +145,7 @@
                                   id="full_description" 
                                   rows="6"
                                   placeholder="Подробное описание компании, её деятельности, достижений и преимуществ"
-                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm @error('full_description') border-red-500 @enderror">{{ old('full_description', $company->full_description) }}</textarea>
+                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm @error('full_description') border-red-500 @enderror">{{ old('full_description', $company->full_description) }}</textarea>
                         @error('full_description')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -172,7 +172,7 @@
                                name="logo" 
                                id="logo" 
                                accept="image/*"
-                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
+                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-emerald-50 file:text-emerald-700 hover:file:bg-emerald-100">
                         <p class="mt-1 text-xs text-gray-500">Форматы: JPG, PNG. Максимальный размер: 2MB</p>
                         @error('logo')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -199,7 +199,7 @@
                                         </div>
                                         <a href="{{ $document->getUrl() }}" 
                                            target="_blank"
-                                           class="text-indigo-600 hover:text-indigo-900 text-sm">
+                                           class="text-emerald-600 hover:text-emerald-900 text-sm">
                                             Скачать
                                         </a>
                                     </div>
@@ -218,7 +218,7 @@
                                id="documents" 
                                accept=".pdf"
                                multiple
-                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
+                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-emerald-50 file:text-emerald-700 hover:file:bg-emerald-100">
                         <p class="mt-1 text-xs text-gray-500">Максимум 10 файлов по 10MB</p>
                         @error('documents.*')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -228,11 +228,11 @@
                     <!-- Кнопки -->
                     <div class="flex items-center justify-end gap-4 pt-4 border-t">
                         <a href="{{ route('companies.show', $company) }}" 
-                           class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                           class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150">
                             Отмена
                         </a>
                         <button type="submit" 
-                                class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 active:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                                class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 active:bg-emerald-900 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150">
                             Сохранить изменения
                         </button>
                     </div>

--- a/resources/views/companies/index.blade.php
+++ b/resources/views/companies/index.blade.php
@@ -13,7 +13,7 @@
             </div>
             @auth
                 <a href="{{ route('companies.create') }}" 
-                   class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 active:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                   class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 active:bg-emerald-900 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150">
                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
                     </svg>
@@ -41,7 +41,7 @@
                                        id="search" 
                                        value="{{ request('search') }}"
                                        placeholder="Название или ИНН"
-                                       class="pl-10 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                       class="pl-10 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm">
                             </div>
                         </div>
 
@@ -50,7 +50,7 @@
                             <label for="industry_id" class="block text-sm font-medium text-gray-700 mb-1">Отрасль</label>
                             <select name="industry_id" 
                                     id="industry_id"
-                                    class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                    class="block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm">
                                 <option value="">Все отрасли</option>
                                 @foreach($industries as $industry)
                                     <option value="{{ $industry->id }}" 
@@ -66,7 +66,7 @@
                             <label for="is_verified" class="block text-sm font-medium text-gray-700 mb-1">Статус</label>
                             <select name="is_verified" 
                                     id="is_verified"
-                                    class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                    class="block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 sm:text-sm">
                                 <option value="">Все компании</option>
                                 <option value="1" {{ request('is_verified') === '1' ? 'selected' : '' }}>Верифицированные</option>
                                 <option value="0" {{ request('is_verified') === '0' ? 'selected' : '' }}>Не верифицированные</option>
@@ -84,7 +84,7 @@
                             Применить фильтры
                         </button>
                         <a href="{{ route('companies.index') }}" 
-                           class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                           class="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150">
                             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/>
                             </svg>
@@ -122,11 +122,11 @@
                     <p class="mt-1 text-sm text-gray-500">
                         Попробуйте изменить параметры поиска или 
                         @auth
-                            <a href="{{ route('companies.create') }}" class="text-indigo-600 hover:text-indigo-900 font-medium">
+                            <a href="{{ route('companies.create') }}" class="text-emerald-600 hover:text-emerald-900 font-medium">
                                 создайте первую компанию!
                             </a>
                         @else
-                            <a href="{{ route('register') }}" class="text-indigo-600 hover:text-indigo-900 font-medium">
+                            <a href="{{ route('register') }}" class="text-emerald-600 hover:text-emerald-900 font-medium">
                                 зарегистрируйтесь, чтобы добавить компанию.
                             </a>
                         @endauth

--- a/resources/views/companies/show.blade.php
+++ b/resources/views/companies/show.blade.php
@@ -34,7 +34,7 @@
                                  alt="{{ $company->name }}"
                                  class="w-24 h-24 rounded-lg object-cover shadow-md">
                         @else
-                            <div class="w-24 h-24 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-lg flex items-center justify-center shadow-md">
+                            <div class="w-24 h-24 bg-gradient-to-br from-emerald-500 to-purple-600 rounded-lg flex items-center justify-center shadow-md">
                                 <span class="text-4xl font-bold text-white">
                                     {{ substr($company->name, 0, 1) }}
                                 </span>
@@ -87,7 +87,7 @@
                             @if($company->canManageModerators(auth()->user()))
                                 <!-- Кнопка редактирования (для модераторов) -->
                                 <a href="{{ route('companies.edit', $company) }}" 
-                                   class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                   class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                                     <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
                                     </svg>
@@ -143,7 +143,7 @@
                 <nav class="-mb-px flex space-x-8 px-6" aria-label="Tabs">
                     <button onclick="showTab('description')" 
                             id="tab-description"
-                            class="tab-button border-indigo-500 text-indigo-600 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
+                            class="tab-button border-emerald-500 text-emerald-600 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
                         Описание
                     </button>
                     <button onclick="showTab('documents')"
@@ -248,15 +248,15 @@
                                                 file:mr-4 file:py-2 file:px-4
                                                 file:rounded-md file:border-0
                                                 file:text-sm file:font-semibold
-                                                file:bg-indigo-50 file:text-indigo-700
-                                                hover:file:bg-indigo-100 cursor-pointer"
+                                                file:bg-emerald-50 file:text-emerald-700
+                                                hover:file:bg-emerald-100 cursor-pointer"
                                         >
                                         @error('photos.*')
                                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                                         @enderror
                                         <p class="mt-1 text-xs text-gray-500">Можно выбрать несколько файлов. JPG, PNG, GIF или WebP. Максимум 5 МБ каждый.</p>
                                     </div>
-                                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:bg-indigo-700 active:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+                                    <button type="submit" class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 focus:bg-emerald-700 active:bg-emerald-900 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150">
                                         <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"></path>
                                         </svg>
@@ -323,8 +323,8 @@
                         <div class="space-y-3">
                             @foreach($company->moderators as $moderator)
                                 <div class="flex items-center p-4 bg-gray-50 rounded-lg">
-                                    <div class="w-12 h-12 rounded-full bg-indigo-100 flex items-center justify-center mr-4">
-                                        <span class="text-base font-semibold text-indigo-600">
+                                    <div class="w-12 h-12 rounded-full bg-emerald-100 flex items-center justify-center mr-4">
+                                        <span class="text-base font-semibold text-emerald-600">
                                             {{ strtoupper(substr($moderator->name, 0, 2)) }}
                                         </span>
                                     </div>
@@ -332,7 +332,7 @@
                                         <p class="text-sm font-semibold text-gray-900">{{ $moderator->name }}</p>
                                         <p class="text-xs text-gray-500">{{ $moderator->email }}</p>
                                         @if($moderator->pivot->role)
-                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mt-1">
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-emerald-100 text-emerald-800 mt-1">
                                                 {{ $moderator->pivot->role }}
                                             </span>
                                         @endif
@@ -373,8 +373,8 @@
                                             <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
                                                 <div class="flex items-start justify-between">
                                                     <div class="flex items-start flex-1">
-                                                        <div class="w-12 h-12 rounded-full bg-indigo-100 flex items-center justify-center mr-4">
-                                                            <span class="text-lg font-semibold text-indigo-600">
+                                                        <div class="w-12 h-12 rounded-full bg-emerald-100 flex items-center justify-center mr-4">
+                                                            <span class="text-lg font-semibold text-emerald-600">
                                                                 {{ strtoupper(substr($joinRequest->user->name, 0, 2)) }}
                                                             </span>
                                                         </div>
@@ -438,7 +438,7 @@
                                             <select name="user_id" 
                                                     id="user_id" 
                                                     required
-                                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                                 <option value="">Выберите...</option>
                                                 @foreach(\App\Models\User::whereNotIn('id', $company->moderators->pluck('id'))->orderBy('name')->get() as $user)
                                                     <option value="{{ $user->id }}">{{ $user->name }} ({{ $user->email }})</option>
@@ -454,7 +454,7 @@
                                                    name="role" 
                                                    id="role"
                                                    placeholder="Например: Менеджер"
-                                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                         </div>
                                         
                                         <div class="flex items-end">
@@ -462,14 +462,14 @@
                                                 <input type="checkbox" 
                                                        name="can_manage_moderators" 
                                                        value="1"
-                                                       class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                                       class="rounded border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                                 <span class="ml-2 text-sm text-gray-700">Может управлять модераторами</span>
                                             </label>
                                         </div>
                                     </div>
                                     
                                     <button type="submit" 
-                                            class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                            class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                                         Добавить модератора
                                     </button>
                                 </form>
@@ -486,8 +486,8 @@
                                         @foreach($company->moderators as $moderator)
                                             <div class="flex items-center justify-between p-4 bg-gray-50 rounded-lg border border-gray-200">
                                                 <div class="flex items-center flex-1">
-                                                    <div class="w-12 h-12 rounded-full bg-indigo-100 flex items-center justify-center mr-4">
-                                                        <span class="text-base font-semibold text-indigo-600">
+                                                    <div class="w-12 h-12 rounded-full bg-emerald-100 flex items-center justify-center mr-4">
+                                                        <span class="text-base font-semibold text-emerald-600">
                                                             {{ strtoupper(substr($moderator->name, 0, 2)) }}
                                                         </span>
                                                     </div>
@@ -497,7 +497,7 @@
                                                         
                                                         <div class="flex items-center space-x-2 mt-1">
                                                             @if($moderator->pivot->role)
-                                                                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                                                                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-emerald-100 text-emerald-800">
                                                                     {{ $moderator->pivot->role }}
                                                                 </span>
                                                             @endif
@@ -565,7 +565,7 @@
                            name="desired_role" 
                            id="desired_role"
                            placeholder="Например: Менеджер по продажам"
-                           class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                           class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                 </div>
                 
                 <div class="mb-4">
@@ -576,7 +576,7 @@
                               id="message"
                               rows="4"
                               placeholder="Расскажите о себе..."
-                              class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"></textarea>
+                              class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500"></textarea>
                 </div>
                 
                 <div class="flex justify-end space-x-2">
@@ -623,7 +623,7 @@
                            name="role"
                            id="approve_role"
                            placeholder="Например: Менеджер"
-                           class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                           class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                     <p class="text-xs text-gray-500 mt-1">Оставьте пустым, чтобы использовать роль из запроса</p>
                 </div>
 
@@ -671,7 +671,7 @@
                               id="review_comment"
                               rows="3"
                               placeholder="Укажите причину..."
-                              class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"></textarea>
+                              class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500"></textarea>
                 </div>
 
                 <div class="flex justify-end space-x-2">
@@ -701,7 +701,7 @@ function showTab(tabName) {
     
     // Убрать активное состояние у всех кнопок
     document.querySelectorAll('.tab-button').forEach(button => {
-        button.classList.remove('border-indigo-500', 'text-indigo-600');
+        button.classList.remove('border-emerald-500', 'text-emerald-600');
         button.classList.add('border-transparent', 'text-gray-500');
     });
     
@@ -711,7 +711,7 @@ function showTab(tabName) {
     // Активировать выбранную кнопку
     const activeButton = document.getElementById('tab-' + tabName);
     activeButton.classList.remove('border-transparent', 'text-gray-500');
-    activeButton.classList.add('border-indigo-500', 'text-indigo-600');
+    activeButton.classList.add('border-emerald-500', 'text-emerald-600');
 }
 
 // Модальное окно присоединения

--- a/resources/views/components/auction-card.blade.php
+++ b/resources/views/components/auction-card.blade.php
@@ -20,7 +20,7 @@
                 }
             } elseif ($auction->status === 'trading') {
                 $statusLabel = 'Торги';
-                $statusColor = 'bg-blue-100 text-blue-800';
+                $statusColor = 'bg-emerald-100 text-emerald-800';
             } elseif ($auction->status === 'closed') {
                 $statusLabel = 'Завершён';
                 $statusColor = 'bg-gray-100 text-gray-800';
@@ -39,7 +39,7 @@
 
         <!-- Название -->
         <h3 class="text-lg font-semibold text-gray-900 mb-2">
-            <a href="{{ route('auctions.show', $auction) }}" class="hover:text-indigo-600 transition-colors">
+            <a href="{{ route('auctions.show', $auction) }}" class="hover:text-emerald-600 transition-colors">
                 {{ Str::limit($auction->title, 60) }}
             </a>
         </h3>
@@ -48,7 +48,7 @@
         <div class="mb-3">
             <p class="text-sm text-gray-600">
                 <span class="font-medium">Организатор:</span> 
-                <a href="{{ route('companies.show', $auction->company) }}" class="text-indigo-600 hover:text-indigo-800">
+                <a href="{{ route('companies.show', $auction->company) }}" class="text-emerald-600 hover:text-emerald-800">
                     {{ $auction->company->name }}
                 </a>
             </p>
@@ -99,7 +99,7 @@
         <!-- Кнопка просмотра -->
         <div class="mt-4">
             <a href="{{ route('auctions.show', $auction) }}" 
-               class="block w-full text-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:bg-indigo-700 active:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150">
+               class="block w-full text-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 focus:bg-emerald-700 active:bg-emerald-900 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150">
                 Подробнее
             </a>
         </div>

--- a/resources/views/components/company-card.blade.php
+++ b/resources/views/components/company-card.blade.php
@@ -9,7 +9,7 @@
                      alt="{{ $company->name }}"
                      class="w-16 h-16 rounded-lg object-cover">
             @else
-                <div class="w-16 h-16 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-lg flex items-center justify-center">
+                <div class="w-16 h-16 bg-gradient-to-br from-emerald-500 to-purple-600 rounded-lg flex items-center justify-center">
                     <span class="text-2xl font-bold text-white">
                         {{ substr($company->name, 0, 1) }}
                     </span>
@@ -32,7 +32,7 @@
 
         <!-- Название -->
         <h3 class="text-lg font-semibold text-gray-900 mb-2">
-            <a href="{{ route('companies.show', $company) }}" class="hover:text-indigo-600 transition-colors">
+            <a href="{{ route('companies.show', $company) }}" class="hover:text-emerald-600 transition-colors">
                 {{ $company->name }}
             </a>
         </h3>
@@ -46,7 +46,7 @@
                 ИНН: {{ $company->inn }}
             </span>
             @if($company->legal_form)
-                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-emerald-100 text-emerald-800">
                     {{ $company->legal_form }}
                 </span>
             @endif
@@ -75,7 +75,7 @@
                 {{ $company->creator->name }}
             </div>
             <a href="{{ route('companies.show', $company) }}" 
-               class="text-sm font-medium text-indigo-600 hover:text-indigo-500 flex items-center">
+               class="text-sm font-medium text-emerald-600 hover:text-emerald-500 flex items-center">
                 Подробнее
                 <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>

--- a/resources/views/components/file-upload.blade.php
+++ b/resources/views/components/file-upload.blade.php
@@ -124,12 +124,12 @@
                {{ $multiple ? 'multiple' : '' }}
                {{ $required && !$hasTemp ? 'required' : '' }}
                @change="uploadFile($event)"
-               class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
+               class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-emerald-50 file:text-emerald-700 hover:file:bg-emerald-100">
     </div>
 
     {{-- Прогресс загрузки --}}
     <div x-show="uploading" x-cloak class="flex items-center space-x-3">
-        <svg class="animate-spin h-5 w-5 text-indigo-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <svg class="animate-spin h-5 w-5 text-emerald-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
         </svg>

--- a/resources/views/components/nav-link.blade.php
+++ b/resources/views/components/nav-link.blade.php
@@ -2,7 +2,7 @@
 
 @php
 $classes = ($active ?? false)
-            ? 'inline-flex items-center px-1 pt-1 border-b-2 border-indigo-400 text-sm font-medium leading-5 text-gray-900 focus:outline-none focus:border-indigo-700 transition duration-150 ease-in-out'
+            ? 'inline-flex items-center px-1 pt-1 border-b-2 border-emerald-400 text-sm font-medium leading-5 text-gray-900 focus:outline-none focus:border-emerald-700 transition duration-150 ease-in-out'
             : 'inline-flex items-center px-1 pt-1 border-b-2 border-transparent text-sm font-medium leading-5 text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:outline-none focus:text-gray-700 focus:border-gray-300 transition duration-150 ease-in-out';
 @endphp
 

--- a/resources/views/components/primary-button.blade.php
+++ b/resources/views/components/primary-button.blade.php
@@ -1,3 +1,3 @@
-<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 focus:bg-gray-700 active:bg-gray-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150']) }}>
+<button {{ $attributes->merge(['type' => 'submit', 'class' => 'inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 focus:bg-emerald-700 active:bg-emerald-800 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150']) }}>
     {{ $slot }}
 </button>

--- a/resources/views/components/responsive-nav-link.blade.php
+++ b/resources/views/components/responsive-nav-link.blade.php
@@ -2,7 +2,7 @@
 
 @php
 $classes = ($active ?? false)
-            ? 'block w-full ps-3 pe-4 py-2 border-l-4 border-indigo-400 text-start text-base font-medium text-indigo-700 bg-indigo-50 focus:outline-none focus:text-indigo-800 focus:bg-indigo-100 focus:border-indigo-700 transition duration-150 ease-in-out'
+            ? 'block w-full ps-3 pe-4 py-2 border-l-4 border-emerald-400 text-start text-base font-medium text-emerald-700 bg-emerald-50 focus:outline-none focus:text-emerald-800 focus:bg-emerald-100 focus:border-emerald-700 transition duration-150 ease-in-out'
             : 'block w-full ps-3 pe-4 py-2 border-l-4 border-transparent text-start text-base font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50 hover:border-gray-300 focus:outline-none focus:text-gray-800 focus:bg-gray-50 focus:border-gray-300 transition duration-150 ease-in-out';
 @endphp
 

--- a/resources/views/components/rfq-card.blade.php
+++ b/resources/views/components/rfq-card.blade.php
@@ -5,7 +5,7 @@
         <!-- Заголовок -->
         <div class="flex justify-between items-start mb-3">
             <h3 class="text-xl font-semibold text-gray-900">
-                <a href="{{ route('rfqs.show', $rfq) }}" class="hover:text-indigo-600 transition">
+                <a href="{{ route('rfqs.show', $rfq) }}" class="hover:text-emerald-600 transition">
                     {{ Str::limit($rfq->title, 60) }}
                 </a>
             </h3>
@@ -45,7 +45,7 @@
             <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ $statusColor }}">
                 {{ $statusLabel }}
             </span>
-            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ $rfq->type === 'open' ? 'bg-blue-100 text-blue-800' : 'bg-purple-100 text-purple-800' }}">
+            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ $rfq->type === 'open' ? 'bg-emerald-100 text-emerald-800' : 'bg-purple-100 text-purple-800' }}">
                 {{ $rfq->type === 'open' ? 'Открытая' : 'Закрытая' }}
             </span>
         </div>
@@ -65,7 +65,7 @@
             @endif
             <div>
                 <p class="text-xs text-gray-500">Организатор</p>
-                <a href="{{ route('companies.show', $rfq->company) }}" class="text-sm font-medium text-indigo-600 hover:text-indigo-500">
+                <a href="{{ route('companies.show', $rfq->company) }}" class="text-sm font-medium text-emerald-600 hover:text-emerald-500">
                     {{ Str::limit($rfq->company->name, 30) }}
                 </a>
             </div>
@@ -102,7 +102,7 @@
 
         <!-- Кнопка -->
         <a href="{{ route('rfqs.show', $rfq) }}" 
-           class="block w-full text-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+           class="block w-full text-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
             Подробнее
         </a>
     </div>

--- a/resources/views/components/secondary-button.blade.php
+++ b/resources/views/components/secondary-button.blade.php
@@ -1,3 +1,3 @@
-<button {{ $attributes->merge(['type' => 'button', 'class' => 'inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-25 transition ease-in-out duration-150']) }}>
+<button {{ $attributes->merge(['type' => 'button', 'class' => 'inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 disabled:opacity-25 transition ease-in-out duration-150']) }}>
     {{ $slot }}
 </button>

--- a/resources/views/components/text-input.blade.php
+++ b/resources/views/components/text-input.blade.php
@@ -1,3 +1,3 @@
 @props(['disabled' => false])
 
-<input @disabled($disabled) {{ $attributes->merge(['class' => 'border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm']) }}>
+<input @disabled($disabled) {{ $attributes->merge(['class' => 'border-gray-300 focus:border-emerald-500 focus:ring-emerald-500 rounded-md shadow-sm']) }}>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -26,7 +26,7 @@
                                     <button
                                         id="load-more-btn"
                                         data-offset="20"
-                                        class="inline-flex items-center px-4 py-2 bg-gray-100 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-200 focus:bg-gray-200 active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150"
+                                        class="inline-flex items-center px-4 py-2 bg-gray-100 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-200 focus:bg-gray-200 active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150"
                                     >
                                         <span id="load-more-text">{{ __('Загрузить ещё') }}</span>
                                         <svg id="load-more-spinner" class="hidden animate-spin ml-2 h-4 w-4 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -64,11 +64,11 @@
                             @else
                                 <div class="space-y-3">
                                     @foreach($notifications as $notification)
-                                        <div class="flex items-start space-x-3 p-3 rounded-lg {{ $notification->read_at ? 'bg-gray-50' : 'bg-blue-50' }}">
+                                        <div class="flex items-start space-x-3 p-3 rounded-lg {{ $notification->read_at ? 'bg-gray-50' : 'bg-emerald-50' }}">
                                             <div class="flex-shrink-0">
                                                 @switch($notification->data['type'] ?? '')
                                                     @case('project_invitation')
-                                                        <svg class="h-5 w-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <svg class="h-5 w-5 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"></path>
                                                         </svg>
                                                         @break
@@ -95,7 +95,7 @@
                                             </div>
                                             <div class="flex-1 min-w-0">
                                                 @if(isset($notification->data['url']))
-                                                    <a href="{{ $notification->data['url'] }}" class="text-sm font-medium text-gray-900 hover:text-indigo-600">
+                                                    <a href="{{ $notification->data['url'] }}" class="text-sm font-medium text-gray-900 hover:text-emerald-600">
                                                         @include('partials.notification-text', ['notification' => $notification])
                                                     </a>
                                                 @else
@@ -115,7 +115,7 @@
                                     <div class="mt-4">
                                         <button
                                             id="mark-all-read-btn"
-                                            class="text-sm text-indigo-600 hover:text-indigo-800"
+                                            class="text-sm text-emerald-600 hover:text-emerald-800"
                                         >
                                             {{ __('Отметить все как прочитанные') }}
                                         </button>
@@ -123,7 +123,7 @@
                                 @endif
 
                                 <div class="mt-4 pt-4 border-t border-gray-200">
-                                    <a href="{{ route('notifications.index') }}" class="text-sm text-indigo-600 hover:text-indigo-800">
+                                    <a href="{{ route('notifications.index') }}" class="text-sm text-emerald-600 hover:text-emerald-800">
                                         {{ __('Все уведомления') }} &rarr;
                                     </a>
                                 </div>
@@ -189,8 +189,8 @@
                     .then(data => {
                         if (data.success) {
                             // Обновить UI
-                            document.querySelectorAll('.bg-blue-50').forEach(el => {
-                                el.classList.remove('bg-blue-50');
+                            document.querySelectorAll('.bg-emerald-50').forEach(el => {
+                                el.classList.remove('bg-emerald-50');
                                 el.classList.add('bg-gray-50');
                             });
                             // Убрать бейдж и кнопку

--- a/resources/views/join-requests/index.blade.php
+++ b/resources/views/join-requests/index.blade.php
@@ -23,7 +23,7 @@
                     <p class="mt-1 text-sm text-gray-500">Вы ещё не отправляли запросы на присоединение к компаниям</p>
                     <div class="mt-6">
                         <a href="{{ route('companies.index') }}" 
-                           class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                           class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                             Найти компанию
                         </a>
                     </div>
@@ -39,7 +39,7 @@
                                 <div class="flex-1">
                                     <div class="flex items-center space-x-3 mb-2">
                                         <h3 class="text-xl font-semibold text-gray-900">
-                                            <a href="{{ route('companies.show', $request->company) }}" class="hover:text-indigo-600 transition">
+                                            <a href="{{ route('companies.show', $request->company) }}" class="hover:text-emerald-600 transition">
                                                 {{ $request->company->name }}
                                             </a>
                                         </h3>
@@ -67,7 +67,7 @@
                                     @if($request->desired_role)
                                         <div class="mb-2">
                                             <span class="text-xs text-gray-500">Желаемая роль:</span>
-                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 ml-1">
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-emerald-100 text-emerald-800 ml-1">
                                                 {{ $request->desired_role }}
                                             </span>
                                         </div>
@@ -121,7 +121,7 @@
                                         </form>
                                     @else
                                         <a href="{{ route('companies.show', $request->company) }}" 
-                                           class="inline-flex items-center px-3 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                           class="inline-flex items-center px-3 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                                             Просмотр компании
                                         </a>
                                     @endif

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -34,7 +34,7 @@
                         <div class="relative" x-data="{ open: false }">
                             <button @click="open = ! open" 
                                     class="inline-flex items-center px-1 pt-1 text-sm font-medium leading-5 transition duration-150 ease-in-out border-b-2
-                                        {{ request()->routeIs('rfqs.*', 'auctions.*', 'bids.*', 'invitations.*') ? 'border-indigo-400 text-gray-900 focus:border-indigo-700' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:text-gray-700 focus:border-gray-300' }}">
+                                        {{ request()->routeIs('rfqs.*', 'auctions.*', 'bids.*', 'invitations.*') ? 'border-emerald-400 text-gray-900 focus:border-emerald-700' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:text-gray-700 focus:border-gray-300' }}">
                                 <span>{{ __('Тендеры и Аукционы') }}</span>
                                 <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                                     <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
@@ -96,7 +96,7 @@
                         <div class="relative" x-data="{ open: false }">
                             <button @click="open = ! open" 
                                     class="inline-flex items-center px-1 pt-1 text-sm font-medium leading-5 transition duration-150 ease-in-out border-b-2
-                                        {{ request()->routeIs('news.*', 'profile.keywords.*') ? 'border-indigo-400 text-gray-900 focus:border-indigo-700' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:text-gray-700 focus:border-gray-300' }}">
+                                        {{ request()->routeIs('news.*', 'profile.keywords.*') ? 'border-emerald-400 text-gray-900 focus:border-emerald-700' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:text-gray-700 focus:border-gray-300' }}">
                                 <span>{{ __('Новости') }}</span>
                                 <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                                     <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
@@ -136,7 +136,7 @@
                             @focus="if(results.length > 0) open = true"
                             @keydown.escape="open = false"
                             placeholder="Поиск..."
-                            class="w-48 lg:w-64 pl-9 pr-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500"
+                            class="w-48 lg:w-64 pl-9 pr-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-emerald-500 focus:border-emerald-500"
                         >
                         <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                             <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -176,7 +176,7 @@
                             </template>
                         </div>
                         <div class="px-4 py-2 border-t border-gray-100 bg-gray-50">
-                            <a :href="'{{ route('search.index') }}?q=' + encodeURIComponent(query)" class="block text-center text-sm text-indigo-600 hover:text-indigo-800">
+                            <a :href="'{{ route('search.index') }}?q=' + encodeURIComponent(query)" class="block text-center text-sm text-emerald-600 hover:text-emerald-800">
                                 {{ __('Все результаты') }}
                             </a>
                         </div>
@@ -188,7 +188,7 @@
                     <div class="relative mr-4" x-data="{ open: false, notifications: [], loading: false }">
                         <button
                             @click="open = !open; if(open && notifications.length === 0) { loading = true; fetch('{{ route('notifications.index') }}', {headers: {'Accept': 'application/json'}}).then(r => r.json()).then(d => { notifications = d.notifications || []; loading = false; }).catch(() => loading = false); }"
-                            class="relative p-1 text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 rounded-full"
+                            class="relative p-1 text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500 rounded-full"
                         >
                             <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path>
@@ -225,7 +225,7 @@
                                 <div class="px-4 py-2 border-b border-gray-100">
                                     <div class="flex items-center justify-between">
                                         <span class="text-sm font-semibold text-gray-900">{{ __('Уведомления') }}</span>
-                                        <a href="{{ route('notifications.index') }}" class="text-xs text-indigo-600 hover:text-indigo-800">{{ __('Все') }}</a>
+                                        <a href="{{ route('notifications.index') }}" class="text-xs text-emerald-600 hover:text-emerald-800">{{ __('Все') }}</a>
                                     </div>
                                 </div>
                                 <div class="max-h-96 overflow-y-auto">
@@ -243,7 +243,7 @@
                                         <a
                                             :href="notification.data?.url || '#'"
                                             class="block px-4 py-3 hover:bg-gray-50 border-b border-gray-100 last:border-0"
-                                            :class="{ 'bg-blue-50': !notification.read_at }"
+                                            :class="{ 'bg-emerald-50': !notification.read_at }"
                                         >
                                             <p class="text-sm text-gray-900" x-text="notification.data?.project_title || notification.data?.tender_number || notification.data?.message || 'Новое уведомление'"></p>
                                             <p class="text-xs text-gray-500 mt-1" x-text="new Date(notification.created_at).toLocaleString('ru-RU')"></p>
@@ -251,7 +251,7 @@
                                     </template>
                                 </div>
                                 <div class="px-4 py-2 border-t border-gray-100 bg-gray-50">
-                                    <a href="{{ route('notifications.index') }}" class="block text-center text-sm text-indigo-600 hover:text-indigo-800">
+                                    <a href="{{ route('notifications.index') }}" class="block text-center text-sm text-emerald-600 hover:text-emerald-800">
                                         {{ __('Показать все уведомления') }}
                                     </a>
                                 </div>

--- a/resources/views/news/index.blade.php
+++ b/resources/views/news/index.blade.php
@@ -25,7 +25,7 @@
                             </label>
                             <select name="source_id" 
                                     id="source_id"
-                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <option value="">Все источники</option>
                                 @foreach($sources as $source)
                                     <option value="{{ $source->id }}" 
@@ -45,7 +45,7 @@
                                    name="date" 
                                    id="date"
                                    value="{{ request('date') }}"
-                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                         </div>
 
                         <!-- Фильтр по ключевым словам -->
@@ -60,7 +60,7 @@
                                            id="apply_keywords"
                                            value="1"
                                            {{ request('apply_keywords') ? 'checked' : '' }}
-                                           class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                           class="rounded border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                     <label for="apply_keywords" class="ml-2 text-sm text-gray-600">
                                         Фильтровать по моим ключевым словам
                                         @if(!empty($userKeywords))
@@ -70,7 +70,7 @@
                                 </div>
                                 @if(empty($userKeywords))
                                     <p class="mt-1 text-xs text-gray-500">
-                                        <a href="{{ route('profile.keywords.index') }}" class="text-indigo-600 hover:text-indigo-500">
+                                        <a href="{{ route('profile.keywords.index') }}" class="text-emerald-600 hover:text-emerald-500">
                                             Добавить ключевые слова
                                         </a>
                                     </p>
@@ -82,7 +82,7 @@
                     <!-- Кнопки -->
                     <div class="flex items-center space-x-2">
                         <button type="submit" 
-                                class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"></path>
                             </svg>
@@ -99,11 +99,11 @@
 
                     <!-- Активные ключевые слова -->
                     @if(request('apply_keywords') && !empty($userKeywords))
-                        <div class="mt-3 p-3 bg-blue-50 rounded border border-blue-200">
-                            <p class="text-xs font-medium text-blue-800 mb-2">Фильтрация по ключевым словам (все должны присутствовать):</p>
+                        <div class="mt-3 p-3 bg-emerald-50 rounded border border-emerald-200">
+                            <p class="text-xs font-medium text-emerald-800 mb-2">Фильтрация по ключевым словам (все должны присутствовать):</p>
                             <div class="flex flex-wrap gap-2">
                                 @foreach($userKeywords as $keyword)
-                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-800">
                                         {{ $keyword }}
                                     </span>
                                 @endforeach
@@ -135,7 +135,7 @@
                                 <div class="flex-1">
                                     <!-- Источник и дата -->
                                     <div class="flex items-center text-xs text-gray-500 mb-2">
-                                        <span class="font-semibold text-indigo-600">{{ $item->rssSource->name }}</span>
+                                        <span class="font-semibold text-emerald-600">{{ $item->rssSource->name }}</span>
                                         <span class="mx-2">•</span>
                                         <span>{{ $item->published_at->format('d.m.Y H:i') }}</span>
                                     </div>
@@ -145,7 +145,7 @@
                                         <a href="{{ $item->link }}" 
                                            target="_blank"
                                            rel="noopener noreferrer"
-                                           class="hover:text-indigo-600 transition">
+                                           class="hover:text-emerald-600 transition">
                                             {{ $item->title }}
                                         </a>
                                     </h3>
@@ -161,7 +161,7 @@
                                     <a href="{{ $item->link }}" 
                                        target="_blank"
                                        rel="noopener noreferrer"
-                                       class="inline-flex items-center mt-2 text-sm text-indigo-600 hover:text-indigo-500">
+                                       class="inline-flex items-center mt-2 text-sm text-emerald-600 hover:text-emerald-500">
                                         Читать далее
                                         <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
@@ -188,7 +188,7 @@
                     <p class="mt-1 text-sm text-gray-500">
                         @if(request('apply_keywords'))
                             Попробуйте изменить ключевые слова или 
-                            <a href="{{ route('news.index') }}" class="text-indigo-600 hover:text-indigo-500">
+                            <a href="{{ route('news.index') }}" class="text-emerald-600 hover:text-emerald-500">
                                 показать все новости
                             </a>
                         @else

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -7,7 +7,7 @@
             @if(auth()->user()->unreadNotifications()->count() > 0)
                 <button
                     id="mark-all-read-btn"
-                    class="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                    class="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded text-emerald-700 bg-emerald-100 hover:bg-emerald-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500"
                 >
                     {{ __('Отметить все как прочитанные') }}
                 </button>
@@ -31,14 +31,14 @@
                         <div class="space-y-4" id="notifications-list">
                             @foreach($notifications as $notification)
                                 <div
-                                    class="notification-item flex items-start space-x-4 p-4 rounded-lg border {{ $notification->read_at ? 'bg-gray-50 border-gray-200' : 'bg-blue-50 border-blue-200' }}"
+                                    class="notification-item flex items-start space-x-4 p-4 rounded-lg border {{ $notification->read_at ? 'bg-gray-50 border-gray-200' : 'bg-emerald-50 border-emerald-200' }}"
                                     data-id="{{ $notification->id }}"
                                 >
                                     <div class="flex-shrink-0">
                                         @switch($notification->data['type'] ?? '')
                                             @case('project_invitation')
-                                                <div class="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center">
-                                                    <svg class="h-5 w-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <div class="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center">
+                                                    <svg class="h-5 w-5 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"></path>
                                                     </svg>
                                                 </div>
@@ -83,7 +83,7 @@
                                     <div class="flex-1 min-w-0">
                                         <div class="text-sm font-medium text-gray-900">
                                             @if(isset($notification->data['url']))
-                                                <a href="{{ $notification->data['url'] }}" class="hover:text-indigo-600">
+                                                <a href="{{ $notification->data['url'] }}" class="hover:text-emerald-600">
                                                     @include('partials.notification-text', ['notification' => $notification])
                                                 </a>
                                             @else
@@ -98,7 +98,7 @@
                                     <div class="flex-shrink-0">
                                         @if(!$notification->read_at)
                                             <button
-                                                class="mark-read-btn text-xs text-indigo-600 hover:text-indigo-800"
+                                                class="mark-read-btn text-xs text-emerald-600 hover:text-emerald-800"
                                                 data-id="{{ $notification->id }}"
                                             >
                                                 {{ __('Прочитано') }}
@@ -140,7 +140,7 @@
                     .then(response => response.json())
                     .then(data => {
                         if (data.success) {
-                            item.classList.remove('bg-blue-50', 'border-blue-200');
+                            item.classList.remove('bg-emerald-50', 'border-emerald-200');
                             item.classList.add('bg-gray-50', 'border-gray-200');
                             this.outerHTML = '<span class="text-xs text-gray-400">Прочитано</span>';
                             updateNotificationBadge(data.unreadCount);
@@ -165,7 +165,7 @@
                     .then(data => {
                         if (data.success) {
                             document.querySelectorAll('.notification-item').forEach(item => {
-                                item.classList.remove('bg-blue-50', 'border-blue-200');
+                                item.classList.remove('bg-emerald-50', 'border-emerald-200');
                                 item.classList.add('bg-gray-50', 'border-gray-200');
                             });
                             document.querySelectorAll('.mark-read-btn').forEach(btn => {

--- a/resources/views/partials/activity-items.blade.php
+++ b/resources/views/partials/activity-items.blade.php
@@ -10,8 +10,8 @@
                     $modelName = class_basename($activity->subject_type);
                     switch($modelName) {
                         case 'Company':
-                            $iconColor = 'text-blue-500';
-                            $bgColor = 'bg-blue-100';
+                            $iconColor = 'text-emerald-500';
+                            $bgColor = 'bg-emerald-100';
                             break;
                         case 'Project':
                             $iconColor = 'text-green-500';
@@ -26,8 +26,8 @@
                             $bgColor = 'bg-purple-100';
                             break;
                         case 'Comment':
-                            $iconColor = 'text-indigo-500';
-                            $bgColor = 'bg-indigo-100';
+                            $iconColor = 'text-emerald-500';
+                            $bgColor = 'bg-emerald-100';
                             break;
                     }
                 }
@@ -135,7 +135,7 @@
 
                 <!-- Ссылка на объект -->
                 @if($subjectUrl && $subjectName)
-                    <a href="{{ $subjectUrl }}" class="font-medium text-indigo-600 hover:text-indigo-800">
+                    <a href="{{ $subjectUrl }}" class="font-medium text-emerald-600 hover:text-emerald-800">
                         "{{ $subjectName }}"
                     </a>
                 @elseif($subjectName)

--- a/resources/views/pdfs/my-invitations.blade.php
+++ b/resources/views/pdfs/my-invitations.blade.php
@@ -39,7 +39,7 @@
                                 <div class="flex-1">
                                     <div class="flex items-center space-x-3 mb-2">
                                         <h3 class="text-xl font-semibold text-gray-900">
-                                            <a href="{{ route('rfqs.show', $rfq) }}" class="hover:text-indigo-600 transition">
+                                            <a href="{{ route('rfqs.show', $rfq) }}" class="hover:text-emerald-600 transition">
                                                 {{ $rfq->number }} — {{ $rfq->title }}
                                             </a>
                                         </h3>
@@ -47,7 +47,7 @@
                                             $statusColors = [
                                                 'draft' => 'bg-gray-100 text-gray-800',
                                                 'active' => 'bg-green-100 text-green-800',
-                                                'completed' => 'bg-blue-100 text-blue-800',
+                                                'completed' => 'bg-emerald-100 text-emerald-800',
                                                 'cancelled' => 'bg-red-100 text-red-800',
                                             ];
                                             $statusLabels = [
@@ -93,8 +93,8 @@
                                     </div>
                                     
                                     @if($hasAlreadyBid)
-                                        <div class="mt-3 p-3 bg-blue-50 border border-blue-200 rounded">
-                                            <div class="flex items-center text-blue-800">
+                                        <div class="mt-3 p-3 bg-emerald-50 border border-emerald-200 rounded">
+                                            <div class="flex items-center text-emerald-800">
                                                 <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                                                 </svg>
@@ -121,7 +121,7 @@
                                 <!-- Кнопки действий -->
                                 <div class="ml-4 flex flex-col space-y-2">
                                     <a href="{{ route('rfqs.show', $rfq) }}" 
-                                       class="inline-flex items-center justify-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                       class="inline-flex items-center justify-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                                         Просмотр
                                     </a>
                                     

--- a/resources/views/profile/keywords.blade.php
+++ b/resources/views/profile/keywords.blade.php
@@ -27,14 +27,14 @@
         @endif
 
         <!-- Информация о фильтрации -->
-        <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
+        <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-4 mb-6">
             <div class="flex">
-                <svg class="h-5 w-5 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="h-5 w-5 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                 </svg>
                 <div class="ml-3">
-                    <h3 class="text-sm font-medium text-blue-800">Как работает фильтрация?</h3>
-                    <div class="mt-2 text-sm text-blue-700">
+                    <h3 class="text-sm font-medium text-emerald-800">Как работает фильтрация?</h3>
+                    <div class="mt-2 text-sm text-emerald-700">
                         <ul class="list-disc list-inside space-y-1">
                             <li>Если указано <strong>одно</strong> ключевое слово — показываем новости, содержащие это слово</li>
                             <li>Если указано <strong>несколько</strong> ключевых слов — показываем новости, содержащие <strong>ВСЕ</strong> эти слова одновременно</li>
@@ -62,14 +62,14 @@
                                    placeholder="Например: искусственный интеллект"
                                    maxlength="50"
                                    required
-                                   class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('keyword') border-red-500 @enderror">
+                                   class="block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('keyword') border-red-500 @enderror">
                             @error('keyword')
                                 <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                             @enderror
                         </div>
                         
                         <button type="submit" 
-                                class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                             </svg>
@@ -93,7 +93,7 @@
                     
                     @if($keywords->count() > 0)
                         <a href="{{ route('news.index', ['apply_keywords' => 1]) }}" 
-                           class="text-sm text-indigo-600 hover:text-indigo-500">
+                           class="text-sm text-emerald-600 hover:text-emerald-500">
                             Смотреть новости →
                         </a>
                     @endif

--- a/resources/views/profile/partials/update-avatar-form.blade.php
+++ b/resources/views/profile/partials/update-avatar-form.blade.php
@@ -35,8 +35,8 @@
                             file:mr-4 file:py-2 file:px-4
                             file:rounded-md file:border-0
                             file:text-sm file:font-semibold
-                            file:bg-indigo-50 file:text-indigo-700
-                            hover:file:bg-indigo-100
+                            file:bg-emerald-50 file:text-emerald-700
+                            hover:file:bg-emerald-100
                             cursor-pointer"
                     >
                     <x-input-error class="mt-2" :messages="$errors->get('avatar')" />

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -33,7 +33,7 @@
                     <p class="text-sm mt-2 text-gray-800">
                         {{ __('Your email address is unverified.') }}
 
-                        <button form="send-verification" class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                        <button form="send-verification" class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-emerald-500">
                             {{ __('Click here to re-send the verification email.') }}
                         </button>
                     </p>

--- a/resources/views/projects/create.blade.php
+++ b/resources/views/projects/create.blade.php
@@ -34,7 +34,7 @@
                                id="name"
                                value="{{ old('name') }}"
                                required
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                         @error('name')
                             <p class="text-red-600 text-sm mt-1">{{ $message }}</p>
                         @enderror
@@ -46,7 +46,7 @@
                             Компания-заказчик <span class="text-red-500">*</span>
                         </label>
                         <select name="company_id" id="company_id" required
-                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                             <option value="">Выберите компанию</option>
                             @foreach($companies as $company)
                                 <option value="{{ $company->id }}">{{ $company->name }}</option>
@@ -58,21 +58,21 @@
                     <div class="mb-6">
                         <label for="description" class="block text-sm font-medium text-gray-700 mb-2">Краткое описание</label>
                         <textarea name="description" id="description" rows="3" maxlength="500"
-                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">{{ old('description') }}</textarea>
+                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">{{ old('description') }}</textarea>
                     </div>
 
                     <!-- Полное описание -->
                     <div class="mb-6">
                         <label for="full_description" class="block text-sm font-medium text-gray-700 mb-2">Полное описание</label>
                         <textarea name="full_description" id="full_description" rows="8"
-                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">{{ old('full_description') }}</textarea>
+                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">{{ old('full_description') }}</textarea>
                     </div>
 
                     <!-- Аватар -->
                     <div class="mb-6">
                         <label for="avatar" class="block text-sm font-medium text-gray-700 mb-2">Аватар проекта</label>
                         <input type="file" name="avatar" id="avatar" accept="image/*"
-                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
+                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-emerald-50 file:text-emerald-700 hover:file:bg-emerald-100">
                     </div>
 
                     <!-- Даты -->
@@ -80,12 +80,12 @@
                         <div>
                             <label for="start_date" class="block text-sm font-medium text-gray-700 mb-2">Дата начала <span class="text-red-500">*</span></label>
                             <input type="date" name="start_date" id="start_date" required
-                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                         </div>
                         <div>
                             <label for="end_date" class="block text-sm font-medium text-gray-700 mb-2">Дата окончания</label>
                             <input type="date" name="end_date" id="end_date"
-                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                         </div>
                     </div>
 
@@ -93,7 +93,7 @@
                     <div class="mb-6">
                         <label class="flex items-center">
                             <input type="checkbox" name="is_ongoing" id="is_ongoing" value="1"
-                                   class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                   class="rounded border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                             <span class="ml-2 text-sm text-gray-700">Проект выполняется по настоящее время</span>
                         </label>
                     </div>
@@ -102,7 +102,7 @@
                     <div class="mb-6">
                         <label for="status" class="block text-sm font-medium text-gray-700 mb-2">Статус проекта <span class="text-red-500">*</span></label>
                         <select name="status" id="status" required
-                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                             @foreach(\App\Models\Project::getStatuses() as $value => $label)
                                 <option value="{{ $value }}" {{ old('status', 'active') === $value ? 'selected' : '' }}>{{ $label }}</option>
                             @endforeach
@@ -153,7 +153,7 @@
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-1">Компания</label>
                         <select name="participants[${participantIndex}][company_id]" required
-                                class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
+                                class="block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm">
                             <option value="">Выберите компанию</option>
                             ${allCompanies.map(c => `<option value="${c.id}">${c.name}</option>`).join('')}
                         </select>
@@ -161,7 +161,7 @@
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-1">Роль</label>
                         <select name="participants[${participantIndex}][role]" required
-                                class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">
+                                class="block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm">
                             ${Object.entries(participantRoles).map(([v, l]) => `<option value="${v}">${l}</option>`).join('')}
                         </select>
                     </div>
@@ -175,7 +175,7 @@
                 <div class="mt-3">
                     <label class="block text-sm font-medium text-gray-700 mb-1">Описание участия</label>
                     <textarea name="participants[${participantIndex}][participation_description]" rows="2"
-                              class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"></textarea>
+                              class="block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm"></textarea>
                 </div>
             </div>
         `;

--- a/resources/views/projects/edit.blade.php
+++ b/resources/views/projects/edit.blade.php
@@ -37,7 +37,7 @@
                                    id="name"
                                    value="{{ old('name', $project->name) }}"
                                    required
-                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('name') border-red-500 @enderror">
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('name') border-red-500 @enderror">
                             @error('name')
                                 <p class="text-red-600 text-sm mt-1">{{ $message }}</p>
                             @enderror
@@ -51,7 +51,7 @@
                             <select name="company_id" 
                                     id="company_id"
                                     required
-                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('company_id') border-red-500 @enderror">
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('company_id') border-red-500 @enderror">
                                 <option value="">Выберите компанию</option>
                                 @foreach($companies as $company)
                                     <option value="{{ $company->id }}" {{ old('company_id', $project->company_id) == $company->id ? 'selected' : '' }}>
@@ -73,7 +73,7 @@
                                       id="description"
                                       rows="3"
                                       maxlength="500"
-                                      class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('description') border-red-500 @enderror">{{ old('description', $project->description) }}</textarea>
+                                      class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('description') border-red-500 @enderror">{{ old('description', $project->description) }}</textarea>
                             @error('description')
                                 <p class="text-red-600 text-sm mt-1">{{ $message }}</p>
                             @enderror
@@ -88,7 +88,7 @@
                             <textarea name="full_description" 
                                       id="full_description"
                                       rows="8"
-                                      class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('full_description') border-red-500 @enderror">{{ old('full_description', $project->full_description) }}</textarea>
+                                      class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('full_description') border-red-500 @enderror">{{ old('full_description', $project->full_description) }}</textarea>
                             @error('full_description')
                                 <p class="text-red-600 text-sm mt-1">{{ $message }}</p>
                             @enderror
@@ -115,7 +115,7 @@
                                    name="avatar" 
                                    id="avatar"
                                    accept="image/*"
-                                   class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
+                                   class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-emerald-50 file:text-emerald-700 hover:file:bg-emerald-100">
                             @error('avatar')
                                 <p class="text-red-600 text-sm mt-1">{{ $message }}</p>
                             @enderror
@@ -132,7 +132,7 @@
                                        id="start_date"
                                        value="{{ old('start_date', $project->start_date?->format('Y-m-d')) }}"
                                        required
-                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                             </div>
 
                             <div>
@@ -143,7 +143,7 @@
                                        name="end_date" 
                                        id="end_date"
                                        value="{{ old('end_date', $project->end_date?->format('Y-m-d')) }}"
-                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500"
                                        {{ $project->is_ongoing ? 'disabled' : '' }}>
                             </div>
                         </div>
@@ -156,7 +156,7 @@
                                        id="is_ongoing"
                                        value="1"
                                        {{ old('is_ongoing', $project->is_ongoing) ? 'checked' : '' }}
-                                       class="rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                       class="rounded border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <span class="ml-2 text-sm text-gray-700">
                                     Проект выполняется по настоящее время
                                 </span>
@@ -171,7 +171,7 @@
                             <select name="status" 
                                     id="status"
                                     required
-                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 @foreach(\App\Models\Project::getStatuses() as $value => $label)
                                     <option value="{{ $value }}" {{ old('status', $project->status) === $value ? 'selected' : '' }}>
                                         {{ $label }}
@@ -192,7 +192,7 @@
                                             <div>
                                                 <label class="block text-sm font-medium text-gray-700 mb-1">Компания</label>
                                                 <select name="participants[{{ $index }}][company_id]" 
-                                                        class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+                                                        class="block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm"
                                                         required>
                                                     @foreach($allCompanies as $company)
                                                         <option value="{{ $company->id }}" {{ $participant->id == $company->id ? 'selected' : '' }}>
@@ -204,7 +204,7 @@
                                             <div>
                                                 <label class="block text-sm font-medium text-gray-700 mb-1">Роль</label>
                                                 <select name="participants[{{ $index }}][role]" 
-                                                        class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+                                                        class="block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm"
                                                         required>
                                                     @foreach(\App\Models\Project::getParticipantRoles() as $value => $label)
                                                         <option value="{{ $value }}" {{ $participant->pivot->role === $value ? 'selected' : '' }}>
@@ -225,7 +225,7 @@
                                             <label class="block text-sm font-medium text-gray-700 mb-1">Описание участия</label>
                                             <textarea name="participants[{{ $index }}][participation_description]" 
                                                       rows="2"
-                                                      class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">{{ $participant->pivot->participation_description }}</textarea>
+                                                      class="block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm">{{ $participant->pivot->participation_description }}</textarea>
                                         </div>
                                     </div>
                                 @endforeach
@@ -247,7 +247,7 @@
                                 Отмена
                             </a>
                             <button type="submit" 
-                                    class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                    class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                                 <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                                 </svg>
@@ -274,7 +274,7 @@
                         <div>
                             <label class="block text-sm font-medium text-gray-700 mb-1">Компания</label>
                             <select name="participants[${participantIndex}][company_id]" 
-                                    class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+                                    class="block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm"
                                     required>
                                 <option value="">Выберите компанию</option>
                                 ${allCompanies.map(company => `<option value="${company.id}">${company.name}</option>`).join('')}
@@ -283,7 +283,7 @@
                         <div>
                             <label class="block text-sm font-medium text-gray-700 mb-1">Роль</label>
                             <select name="participants[${participantIndex}][role]" 
-                                    class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+                                    class="block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm"
                                     required>
                                 ${Object.entries(participantRoles).map(([value, label]) => `<option value="${value}">${label}</option>`).join('')}
                             </select>
@@ -300,7 +300,7 @@
                         <label class="block text-sm font-medium text-gray-700 mb-1">Описание участия</label>
                         <textarea name="participants[${participantIndex}][participation_description]" 
                                   rows="2"
-                                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"></textarea>
+                                  class="block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm"></textarea>
                     </div>
                 </div>
             `;

--- a/resources/views/projects/index.blade.php
+++ b/resources/views/projects/index.blade.php
@@ -35,7 +35,7 @@
                                    id="search"
                                    value="{{ request('search') }}"
                                    placeholder="Введите название проекта"
-                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                         </div>
 
                         <!-- Фильтр по статусу -->
@@ -45,7 +45,7 @@
                             </label>
                             <select name="status" 
                                     id="status"
-                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <option value="">Все статусы</option>
                                 @foreach(\App\Models\Project::getStatuses() as $value => $label)
                                     <option value="{{ $value }}" {{ request('status') === $value ? 'selected' : '' }}>
@@ -62,7 +62,7 @@
                             </label>
                             <select name="company_id" 
                                     id="company_id"
-                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <option value="">Все компании</option>
                                 @foreach($companies as $company)
                                     <option value="{{ $company->id }}" {{ request('company_id') == $company->id ? 'selected' : '' }}>
@@ -79,7 +79,7 @@
                             Сбросить
                         </a>
                         <button type="submit" 
-                                class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                             Применить фильтры
                         </button>
                     </div>
@@ -99,7 +99,7 @@
                     @auth
                         <div class="mt-6">
                             <a href="{{ route('projects.create') }}" 
-                               class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                               class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                                 Создать первый проект
                             </a>
                         </div>

--- a/resources/views/projects/partials/comment.blade.php
+++ b/resources/views/projects/partials/comment.blade.php
@@ -33,10 +33,10 @@
                 <textarea name="body" 
                           rows="3"
                           required
-                          class="w-full mt-2 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm">{{ $comment->body }}</textarea>
+                          class="w-full mt-2 rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm">{{ $comment->body }}</textarea>
                 <div class="mt-2 flex space-x-2">
                     <button type="submit" 
-                            class="inline-flex items-center px-3 py-1.5 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                            class="inline-flex items-center px-3 py-1.5 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                         Сохранить
                     </button>
                     <button type="button" 
@@ -52,7 +52,7 @@
                     <!-- Кнопки управления (скрыты при редактировании) -->
                     <div class="comment-actions-{{ $comment->id }} mt-2 flex space-x-3">
                         <button onclick="editComment({{ $comment->id }})" 
-                                class="text-xs text-indigo-600 hover:text-indigo-500 font-medium">
+                                class="text-xs text-emerald-600 hover:text-emerald-500 font-medium">
                             Редактировать
                         </button>
                         <form method="POST" 

--- a/resources/views/projects/partials/project-card.blade.php
+++ b/resources/views/projects/partials/project-card.blade.php
@@ -6,7 +6,7 @@
                  alt="{{ $project->name }}" 
                  class="w-full h-48 object-cover">
         @else
-            <div class="w-full h-48 bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center">
+            <div class="w-full h-48 bg-gradient-to-br from-emerald-500 to-purple-600 flex items-center justify-center">
                 <svg class="w-16 h-16 text-white opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
                 </svg>
@@ -17,7 +17,7 @@
     <div class="p-6">
         <!-- Название и статус -->
         <div class="flex justify-between items-start mb-2">
-            <h3 class="text-lg font-semibold text-gray-900 hover:text-indigo-600">
+            <h3 class="text-lg font-semibold text-gray-900 hover:text-emerald-600">
                 <a href="{{ route('projects.show', $project->slug) }}">
                     {{ $project->name }}
                 </a>
@@ -26,7 +26,7 @@
             @php
                 $statusColors = [
                     'active' => 'bg-green-100 text-green-800',
-                    'completed' => 'bg-blue-100 text-blue-800',
+                    'completed' => 'bg-emerald-100 text-emerald-800',
                     'cancelled' => 'bg-red-100 text-red-800',
                 ];
             @endphp
@@ -98,7 +98,7 @@
 
         <!-- Кнопка "Подробнее" -->
         <a href="{{ route('projects.show', $project->slug) }}" 
-           class="inline-flex items-center text-sm font-medium text-indigo-600 hover:text-indigo-500">
+           class="inline-flex items-center text-sm font-medium text-emerald-600 hover:text-emerald-500">
             Подробнее
             <svg class="ml-1 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -14,7 +14,7 @@
                 @if($project->canManage(auth()->user()))
                     <div class="flex space-x-2">
                         <a href="{{ route('projects.edit', $project->slug) }}" 
-                           class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                           class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
                             </svg>
@@ -51,7 +51,7 @@
                                  alt="{{ $project->name }}" 
                                  class="w-full md:w-64 h-48 object-cover rounded-lg">
                         @else
-                            <div class="w-full md:w-64 h-48 bg-gradient-to-br from-indigo-500 to-purple-600 rounded-lg flex items-center justify-center">
+                            <div class="w-full md:w-64 h-48 bg-gradient-to-br from-emerald-500 to-purple-600 rounded-lg flex items-center justify-center">
                                 <svg class="w-24 h-24 text-white opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
                                 </svg>
@@ -65,7 +65,7 @@
                         @php
                             $statusColors = [
                                 'active' => 'bg-green-100 text-green-800',
-                                'completed' => 'bg-blue-100 text-blue-800',
+                                'completed' => 'bg-emerald-100 text-emerald-800',
                                 'cancelled' => 'bg-red-100 text-red-800',
                             ];
                         @endphp
@@ -89,7 +89,7 @@
                             <div>
                                 <p class="text-xs text-gray-500">Компания-заказчик</p>
                                 <a href="{{ route('companies.show', $project->company->id) }}" 
-                                   class="text-base font-semibold text-indigo-600 hover:text-indigo-500">
+                                   class="text-base font-semibold text-emerald-600 hover:text-emerald-500">
                                     {{ $project->company->name }}
                                 </a>
                             </div>
@@ -122,7 +122,7 @@
                 <nav class="-mb-px flex space-x-8 px-6" aria-label="Tabs">
                     <button onclick="showTab('description')" 
                             id="tab-description"
-                            class="tab-button active border-indigo-500 text-indigo-600 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
+                            class="tab-button active border-emerald-500 text-emerald-600 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
                         Описание
                     </button>
                     <button onclick="showTab('participants')" 
@@ -183,7 +183,7 @@
 
                                     <div class="flex-1">
                                         <a href="{{ route('companies.show', $participant->slug) }}" 
-                                           class="text-lg font-semibold text-indigo-600 hover:text-indigo-500">
+                                           class="text-lg font-semibold text-emerald-600 hover:text-emerald-500">
                                             {{ $participant->name }}
                                         </a>
                                         
@@ -217,7 +217,7 @@
                                       rows="3" 
                                       placeholder="Написать комментарий..."
                                       required
-                                      class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"></textarea>
+                                      class="w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500"></textarea>
                             
                             @error('body')
                                 <p class="text-red-600 text-sm mt-1">{{ $message }}</p>
@@ -225,7 +225,7 @@
 
                             <div class="mt-2 flex justify-end">
                                 <button type="submit" 
-                                        class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                        class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                                     Отправить комментарий
                                 </button>
                             </div>
@@ -233,9 +233,9 @@
                     @else
                         <div class="bg-gray-50 rounded-lg p-4 mb-6 text-center">
                             <p class="text-gray-600">
-                                <a href="{{ route('login') }}" class="text-indigo-600 hover:text-indigo-500 font-semibold">Войдите</a> 
+                                <a href="{{ route('login') }}" class="text-emerald-600 hover:text-emerald-500 font-semibold">Войдите</a> 
                                 или 
-                                <a href="{{ route('register') }}" class="text-indigo-600 hover:text-indigo-500 font-semibold">зарегистрируйтесь</a>, 
+                                <a href="{{ route('register') }}" class="text-emerald-600 hover:text-emerald-500 font-semibold">зарегистрируйтесь</a>, 
                                 чтобы оставить комментарий
                             </p>
                         </div>
@@ -267,7 +267,7 @@
         
         // Убираем активный класс у всех кнопок
         document.querySelectorAll('.tab-button').forEach(button => {
-            button.classList.remove('active', 'border-indigo-500', 'text-indigo-600');
+            button.classList.remove('active', 'border-emerald-500', 'text-emerald-600');
             button.classList.add('border-transparent', 'text-gray-500');
         });
         
@@ -277,7 +277,7 @@
         // Активируем кнопку
         const activeButton = document.getElementById('tab-' + tabName);
         activeButton.classList.remove('border-transparent', 'text-gray-500');
-        activeButton.classList.add('active', 'border-indigo-500', 'text-indigo-600');
+        activeButton.classList.add('active', 'border-emerald-500', 'text-emerald-600');
     }
 
     // ========================

--- a/resources/views/rfqs/create.blade.php
+++ b/resources/views/rfqs/create.blade.php
@@ -26,7 +26,7 @@
                         <select name="company_id" 
                                 id="company_id" 
                                 required
-                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('company_id') border-red-500 @enderror">
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('company_id') border-red-500 @enderror">
                             <option value="">Выберите компанию</option>
                             @foreach($companies as $company)
                                 <option value="{{ $company->id }}" {{ old('company_id') == $company->id ? 'selected' : '' }}>
@@ -49,7 +49,7 @@
                                id="title" 
                                required
                                value="{{ old('title') }}"
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('title') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('title') border-red-500 @enderror">
                         @error('title')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -63,7 +63,7 @@
                         <textarea name="description" 
                                   id="description" 
                                   rows="5"
-                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('description') border-red-500 @enderror">{{ old('description') }}</textarea>
+                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('description') border-red-500 @enderror">{{ old('description') }}</textarea>
                         @error('description')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -80,7 +80,7 @@
                                        name="type" 
                                        value="open" 
                                        {{ old('type', 'open') === 'open' ? 'checked' : '' }}
-                                       class="rounded-full border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                       class="rounded-full border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <span class="ml-2 text-sm text-gray-700">
                                     <strong>Открытая</strong> — любая компания может подать заявку
                                 </span>
@@ -90,7 +90,7 @@
                                        name="type" 
                                        value="closed"
                                        {{ old('type') === 'closed' ? 'checked' : '' }}
-                                       class="rounded-full border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                       class="rounded-full border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <span class="ml-2 text-sm text-gray-700">
                                     <strong>Закрытая</strong> — только приглашённые компании
                                 </span>
@@ -108,7 +108,7 @@
                                     name="status" 
                                     value="draft" 
                                     {{ old('status', 'draft') === 'draft' ? 'checked' : '' }}
-                                    class="mt-1 rounded-full border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                    class="mt-1 rounded-full border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <div class="ml-3">
                                     <span class="text-sm font-semibold text-gray-900">Черновик</span>
                                     <p class="text-xs text-gray-500 mt-1">
@@ -121,7 +121,7 @@
                                     name="status" 
                                     value="active"
                                     {{ old('status') === 'active' ? 'checked' : '' }}
-                                    class="mt-1 rounded-full border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                    class="mt-1 rounded-full border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <div class="ml-3">
                                     <span class="text-sm font-semibold text-gray-900">Активный (опубликовать сразу)</span>
                                     <p class="text-xs text-gray-500 mt-1">
@@ -143,7 +143,7 @@
                         <select name="invited_companies[]" 
                                 multiple 
                                 size="8"
-                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                             @foreach($availableCompanies as $company)
                                 <option value="{{ $company->id }}" 
                                         {{ in_array($company->id, old('invited_companies', [])) ? 'selected' : '' }}>
@@ -165,7 +165,7 @@
                                    id="start_date"
                                    required
                                    value="{{ old('start_date') }}"
-                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('start_date') border-red-500 @enderror">
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('start_date') border-red-500 @enderror">
                             <p class="mt-1 text-xs text-gray-500">UTC +3 (Москва)</p>
                             @error('start_date')
                                 <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -180,7 +180,7 @@
                                    id="end_date"
                                    required
                                    value="{{ old('end_date') }}"
-                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('end_date') border-red-500 @enderror">
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('end_date') border-red-500 @enderror">
                             <p class="mt-1 text-xs text-gray-500">UTC +3 (Москва)</p>
                             @error('end_date')
                                 <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -206,7 +206,7 @@
                                        min="0" 
                                        max="100" 
                                        step="0.01"
-                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('weight_price') border-red-500 @enderror">
+                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('weight_price') border-red-500 @enderror">
                                 @error('weight_price')
                                     <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                                 @enderror
@@ -223,7 +223,7 @@
                                        min="0" 
                                        max="100" 
                                        step="0.01"
-                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('weight_deadline') border-red-500 @enderror">
+                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('weight_deadline') border-red-500 @enderror">
                                 @error('weight_deadline')
                                     <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                                 @enderror
@@ -240,7 +240,7 @@
                                        min="0" 
                                        max="100" 
                                        step="0.01"
-                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('weight_advance') border-red-500 @enderror">
+                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('weight_advance') border-red-500 @enderror">
                                 @error('weight_advance')
                                     <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                                 @enderror
@@ -277,7 +277,7 @@
                             <input type="checkbox" 
                                    id="agreement" 
                                    required
-                                   class="mt-1 rounded border-gray-300 text-indigo-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                   class="mt-1 rounded border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                             <span class="ml-2 text-sm text-gray-700">
                                 Я уведомлён, что процедура проведения Запроса котировок не является публичной офертой и не обязывает к заключению договора. Организатор вправе отменить процедуру на любом этапе без объяснения причин.
                             </span>

--- a/resources/views/rfqs/edit.blade.php
+++ b/resources/views/rfqs/edit.blade.php
@@ -29,7 +29,7 @@
                                id="title" 
                                required
                                value="{{ old('title', $rfq->title) }}"
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('title') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('title') border-red-500 @enderror">
                         @error('title')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -43,7 +43,7 @@
                         <textarea name="description" 
                                   id="description" 
                                   rows="5"
-                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('description') border-red-500 @enderror">{{ old('description', $rfq->description) }}</textarea>
+                                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('description') border-red-500 @enderror">{{ old('description', $rfq->description) }}</textarea>
                         @error('description')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -59,7 +59,7 @@
                                id="end_date" 
                                required
                                value="{{ old('end_date', $rfq->end_date->format('Y-m-d\TH:i')) }}"
-                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 @error('end_date') border-red-500 @enderror">
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('end_date') border-red-500 @enderror">
                         @error('end_date')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
                         @enderror
@@ -87,7 +87,7 @@
                                 </div>
                                 <a href="{{ $rfq->getFirstMediaUrl('technical_specification') }}" 
                                    target="_blank"
-                                   class="text-sm text-indigo-600 hover:text-indigo-500">
+                                   class="text-sm text-emerald-600 hover:text-emerald-500">
                                     Просмотр
                                 </a>
                             </div>
@@ -97,7 +97,7 @@
                                name="technical_specification" 
                                id="technical_specification" 
                                accept="application/pdf"
-                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100 @error('technical_specification') border-red-500 @enderror">
+                               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-emerald-50 file:text-emerald-700 hover:file:bg-emerald-100 @error('technical_specification') border-red-500 @enderror">
                         <p class="mt-1 text-sm text-gray-500">Оставьте пустым, если не хотите заменять файл. Максимальный размер: 10 МБ</p>
                         @error('technical_specification')
                             <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
@@ -111,7 +111,7 @@
                             Отмена
                         </a>
                         <button type="submit" 
-                                class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                             Сохранить изменения
                         </button>
                     </div>

--- a/resources/views/rfqs/index.blade.php
+++ b/resources/views/rfqs/index.blade.php
@@ -37,7 +37,7 @@
                                    id="search"
                                    value="{{ request('search') }}"
                                    placeholder="Название или номер"
-                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                   class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                         </div>
 
                         <!-- Статус -->
@@ -47,7 +47,7 @@
                             </label>
                             <select name="status" 
                                     id="status"
-                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <option value="">Все статусы</option>
                                 <option value="active" {{ request('status') === 'active' ? 'selected' : '' }}>Активные</option>
                                 <option value="closed" {{ request('status') === 'closed' ? 'selected' : '' }}>Завершённые</option>
@@ -62,7 +62,7 @@
                             </label>
                             <select name="type" 
                                     id="type"
-                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <option value="">Все типы</option>
                                 <option value="open" {{ request('type') === 'open' ? 'selected' : '' }}>Открытые</option>
                                 <option value="closed" {{ request('type') === 'closed' ? 'selected' : '' }}>Закрытые</option>
@@ -72,7 +72,7 @@
                         <!-- Кнопки -->
                         <div class="flex items-end space-x-2">
                             <button type="submit" 
-                                    class="flex-1 inline-flex justify-center items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                    class="flex-1 inline-flex justify-center items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                                 Применить
                             </button>
                             <a href="{{ route('rfqs.index') }}" 
@@ -98,7 +98,7 @@
                         @if(auth()->user()->isModeratorOfAnyCompany())
                             <div class="mt-6">
                                 <a href="{{ route('rfqs.create') }}" 
-                                   class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                   class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                                     Разместить первый RFQ
                                 </a>
                             </div>

--- a/resources/views/rfqs/my-bids.blade.php
+++ b/resources/views/rfqs/my-bids.blade.php
@@ -23,7 +23,7 @@
                     <p class="mt-1 text-sm text-gray-500">Найдите подходящий тендер и подайте заявку</p>
                     <div class="mt-6">
                         <a href="{{ route('rfqs.index') }}" 
-                           class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                           class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                             Найти тендеры
                         </a>
                     </div>
@@ -39,14 +39,14 @@
                                 <div class="flex-1">
                                     <div class="flex items-center space-x-3 mb-2">
                                         <h3 class="text-xl font-semibold text-gray-900">
-                                            <a href="{{ route('rfqs.show', $bid->rfq) }}" class="hover:text-indigo-600 transition">
+                                            <a href="{{ route('rfqs.show', $bid->rfq) }}" class="hover:text-emerald-600 transition">
                                                 {{ $bid->rfq->title }}
                                             </a>
                                         </h3>
                                         @php
                                             $statusColors = [
                                                 'pending' => 'bg-yellow-100 text-yellow-800',
-                                                'accepted' => 'bg-blue-100 text-blue-800',
+                                                'accepted' => 'bg-emerald-100 text-emerald-800',
                                                 'rejected' => 'bg-red-100 text-red-800',
                                                 'winner' => 'bg-green-100 text-green-800',
                                             ];
@@ -106,7 +106,7 @@
                                 <!-- Кнопка -->
                                 <div class="ml-4">
                                     <a href="{{ route('rfqs.show', $bid->rfq) }}" 
-                                       class="inline-flex items-center px-3 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                       class="inline-flex items-center px-3 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                                         Просмотр тендера
                                     </a>
                                 </div>

--- a/resources/views/rfqs/my-invitations.blade.php
+++ b/resources/views/rfqs/my-invitations.blade.php
@@ -26,14 +26,14 @@
         @else
             <div class="space-y-4">
                 @foreach($invitations as $invitation)
-                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg hover:shadow-lg transition-shadow duration-300 {{ $invitation->rfq->isActive() ? 'border-l-4 border-indigo-500' : '' }}">
+                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg hover:shadow-lg transition-shadow duration-300 {{ $invitation->rfq->isActive() ? 'border-l-4 border-emerald-500' : '' }}">
                         <div class="p-6">
                             <div class="flex justify-between items-start">
                                 <!-- Информация -->
                                 <div class="flex-1">
                                     <div class="flex items-center space-x-3 mb-2">
                                         <h3 class="text-xl font-semibold text-gray-900">
-                                            <a href="{{ route('rfqs.show', $invitation->rfq) }}" class="hover:text-indigo-600 transition">
+                                            <a href="{{ route('rfqs.show', $invitation->rfq) }}" class="hover:text-emerald-600 transition">
                                                 {{ $invitation->rfq->title }}
                                             </a>
                                         </h3>
@@ -98,7 +98,7 @@
                                 <!-- Кнопка -->
                                 <div class="ml-4">
                                     <a href="{{ route('rfqs.show', $invitation->rfq) }}" 
-                                       class="inline-flex items-center px-4 py-2 {{ $invitation->rfq->isActive() ? 'bg-indigo-600 hover:bg-indigo-700' : 'bg-gray-600 hover:bg-gray-700' }} border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest transition">
+                                       class="inline-flex items-center px-4 py-2 {{ $invitation->rfq->isActive() ? 'bg-emerald-600 hover:bg-emerald-700' : 'bg-gray-600 hover:bg-gray-700' }} border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest transition">
                                         {{ $invitation->rfq->isActive() ? 'Подать заявку' : 'Просмотр' }}
                                     </a>
                                 </div>

--- a/resources/views/rfqs/my-rfqs.blade.php
+++ b/resources/views/rfqs/my-rfqs.blade.php
@@ -29,7 +29,7 @@
                     <p class="mt-1 text-sm text-gray-500">Разместите первый запрос котировок</p>
                     <div class="mt-6">
                         <a href="{{ route('rfqs.create') }}" 
-                           class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                           class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                             Разместить первый RFQ
                         </a>
                     </div>
@@ -45,7 +45,7 @@
                                 <div class="flex-1">
                                     <div class="flex items-center space-x-3 mb-2">
                                         <h3 class="text-xl font-semibold text-gray-900">
-                                            <a href="{{ route('rfqs.show', $rfq) }}" class="hover:text-indigo-600 transition">
+                                            <a href="{{ route('rfqs.show', $rfq) }}" class="hover:text-emerald-600 transition">
                                                 {{ $rfq->title }}
                                             </a>
                                         </h3>
@@ -97,7 +97,7 @@
                                 <!-- Кнопки действий -->
                                 <div class="flex space-x-2 ml-4">
                                     <a href="{{ route('rfqs.show', $rfq) }}" 
-                                       class="inline-flex items-center px-3 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                                       class="inline-flex items-center px-3 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                                         Просмотр
                                     </a>
                                     @if($rfq->status === 'draft')

--- a/resources/views/rfqs/show.blade.php
+++ b/resources/views/rfqs/show.blade.php
@@ -33,7 +33,7 @@
                     <!-- Кнопка редактирования (только для черновиков) -->
                     @if($rfq->status === 'draft')
                         <a href="{{ route('rfqs.edit', $rfq) }}" 
-                        class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition">
+                        class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
                             <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
                             </svg>
@@ -87,7 +87,7 @@
                             <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{ $statusColors[$rfq->status] }}">
                                 {{ $statusLabels[$rfq->status] }}
                             </span>
-                            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{ $rfq->type === 'open' ? 'bg-blue-100 text-blue-800' : 'bg-purple-100 text-purple-800' }}">
+                            <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{ $rfq->type === 'open' ? 'bg-emerald-100 text-emerald-800' : 'bg-purple-100 text-purple-800' }}">
                                 {{ $rfq->type === 'open' ? 'Открытая процедура' : 'Закрытая процедура' }}
                             </span>
                         </div>
@@ -108,7 +108,7 @@
                             <div>
                                 <p class="text-xs text-gray-500">Организатор</p>
                                 <a href="{{ route('companies.show', $rfq->company) }}" 
-                                   class="text-base font-semibold text-indigo-600 hover:text-indigo-500">
+                                   class="text-base font-semibold text-emerald-600 hover:text-emerald-500">
                                     {{ $rfq->company->name }}
                                 </a>
                             </div>
@@ -150,7 +150,7 @@
 
                             {{-- T5: Формула расчёта балла --}}
                             <details class="mt-3">
-                                <summary class="text-xs text-indigo-600 cursor-pointer hover:text-indigo-800">
+                                <summary class="text-xs text-emerald-600 cursor-pointer hover:text-emerald-800">
                                     Как рассчитывается итоговый балл?
                                 </summary>
                                 <div class="mt-2 p-3 bg-white rounded border border-gray-200 text-xs text-gray-600">
@@ -168,7 +168,7 @@
                         @if($rfq->hasMedia('technical_specification'))
                             <a href="{{ $rfq->getFirstMediaUrl('technical_specification') }}" 
                                target="_blank"
-                               class="block w-full text-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 transition mb-4">
+                               class="block w-full text-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition mb-4">
                                 <svg class="w-4 h-4 inline mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
                                 </svg>
@@ -184,9 +184,9 @@
                                     <input type="text" readonly
                                            id="rfq-link"
                                            value="{{ route('rfqs.show', $rfq) }}"
-                                           class="flex-1 text-xs rounded border-gray-300 bg-white focus:ring-indigo-500">
+                                           class="flex-1 text-xs rounded border-gray-300 bg-white focus:ring-emerald-500">
                                     <button type="button" onclick="copyRfqLink()"
-                                            class="px-3 py-2 bg-indigo-600 text-white text-xs rounded hover:bg-indigo-700 transition">
+                                            class="px-3 py-2 bg-emerald-600 text-white text-xs rounded hover:bg-emerald-700 transition">
                                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
                                         </svg>
@@ -237,7 +237,7 @@
                 <nav class="-mb-px flex space-x-8 px-6" aria-label="Tabs">
                     <button onclick="showTab('description')" 
                             id="tab-description"
-                            class="tab-button active border-indigo-500 text-indigo-600 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
+                            class="tab-button active border-emerald-500 text-emerald-600 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
                         Описание
                     </button>
                     <button onclick="showTab('bids')" 
@@ -368,7 +368,7 @@
                 </div>
 
                 {{-- T5: Информация о формуле расчёта в форме заявки --}}
-                <div class="mb-4 p-3 bg-blue-50 border border-blue-200 rounded text-xs text-blue-800">
+                <div class="mb-4 p-3 bg-emerald-50 border border-emerald-200 rounded text-xs text-emerald-800">
                     <p class="font-medium mb-1">Как оценивается ваша заявка:</p>
                     <p>• Чем ниже цена — тем больше баллов (вес {{ $rfq->weight_price }}%)</p>
                     <p>• Чем короче срок — тем больше баллов (вес {{ $rfq->weight_deadline }}%)</p>
@@ -401,22 +401,22 @@
             </form>
         </div>
     @elseif($alreadyBid)
-        <div class="bg-blue-50 border border-blue-200 rounded-lg p-6 mb-6">
+        <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-6 mb-6">
             <div class="flex items-center">
-                <svg class="w-6 h-6 text-blue-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-6 h-6 text-emerald-600 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                 </svg>
-                <p class="text-blue-800 font-medium">Вы уже подали заявку на этот запрос котировок</p>
+                <p class="text-emerald-800 font-medium">Вы уже подали заявку на этот запрос котировок</p>
             </div>
         </div>
     @endif
 @endauth
                     @elseif(!auth()->check())
-                        <div class="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6 text-center">
+                        <div class="bg-emerald-50 border border-emerald-200 rounded-lg p-4 mb-6 text-center">
                             <p class="text-gray-700">
-                                <a href="{{ route('login') }}" class="text-indigo-600 hover:text-indigo-500 font-semibold">Войдите</a> 
+                                <a href="{{ route('login') }}" class="text-emerald-600 hover:text-emerald-500 font-semibold">Войдите</a> 
                                 или 
-                                <a href="{{ route('register') }}" class="text-indigo-600 hover:text-indigo-500 font-semibold">зарегистрируйтесь</a>, 
+                                <a href="{{ route('register') }}" class="text-emerald-600 hover:text-emerald-500 font-semibold">зарегистрируйтесь</a>, 
                                 чтобы подать заявку
                             </p>
                         </div>
@@ -461,19 +461,19 @@
                                         @php
                                             $isUserBid = in_array($bid->company_id, $userCompanyIds);
                                         @endphp
-                                        <tr class="{{ $bid->status === 'winner' ? 'bg-green-50' : ($isUserBid ? 'bg-blue-50' : '') }}">
+                                        <tr class="{{ $bid->status === 'winner' ? 'bg-green-50' : ($isUserBid ? 'bg-emerald-50' : '') }}">
                                             <td class="px-6 py-4 whitespace-nowrap">
                                                 @if($canSeeNames)
                                                     {{-- T2: После закрытия или для организатора показываем названия --}}
-                                                    <a href="{{ route('companies.show', $bid->company) }}" class="text-sm font-medium text-indigo-600 hover:text-indigo-500">
+                                                    <a href="{{ route('companies.show', $bid->company) }}" class="text-sm font-medium text-emerald-600 hover:text-emerald-500">
                                                         {{ $bid->company->name }}
                                                     </a>
                                                 @else
                                                     {{-- T2: На активном этапе показываем анонимный номер --}}
-                                                    <span class="text-sm font-medium {{ $isUserBid ? 'text-blue-600' : 'text-gray-900' }}">
+                                                    <span class="text-sm font-medium {{ $isUserBid ? 'text-emerald-600' : 'text-gray-900' }}">
                                                         Участник {{ $index + 1 }}
                                                         @if($isUserBid)
-                                                            <span class="text-xs text-blue-500">(вы)</span>
+                                                            <span class="text-xs text-emerald-500">(вы)</span>
                                                         @endif
                                                     </span>
                                                 @endif
@@ -550,7 +550,7 @@
                                             @endif
                                             <div>
                                                 <a href="{{ route('companies.show', $invitation->company) }}" 
-                                                   class="text-sm font-medium text-indigo-600 hover:text-indigo-500">
+                                                   class="text-sm font-medium text-emerald-600 hover:text-emerald-500">
                                                     {{ $invitation->company->name }}
                                                 </a>
                                                 <p class="text-xs text-gray-500">
@@ -605,7 +605,7 @@
         
         // Убираем активный класс у всех кнопок
         document.querySelectorAll('.tab-button').forEach(button => {
-            button.classList.remove('active', 'border-indigo-500', 'text-indigo-600');
+            button.classList.remove('active', 'border-emerald-500', 'text-emerald-600');
             button.classList.add('border-transparent', 'text-gray-500');
         });
         
@@ -615,7 +615,7 @@
         // Активируем кнопку
         const activeButton = document.getElementById('tab-' + tabName);
         activeButton.classList.remove('border-transparent', 'text-gray-500');
-        activeButton.classList.add('active', 'border-indigo-500', 'text-indigo-600');
+        activeButton.classList.add('active', 'border-emerald-500', 'text-emerald-600');
     }
 </script>
 @endpush

--- a/resources/views/search/index.blade.php
+++ b/resources/views/search/index.blade.php
@@ -17,13 +17,13 @@
                                 name="q"
                                 value="{{ $query }}"
                                 placeholder="Поиск по компаниям, проектам, тендерам..."
-                                class="w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"
+                                class="w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500"
                                 autofocus
                             >
                         </div>
                         <button
                             type="submit"
-                            class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-700 focus:bg-indigo-700 active:bg-indigo-900 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition ease-in-out duration-150"
+                            class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 focus:bg-emerald-700 active:bg-emerald-900 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150"
                         >
                             <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
@@ -43,36 +43,36 @@
                                 <h3 class="font-semibold text-gray-900 mb-4">Тип</h3>
                                 <nav class="space-y-1">
                                     <a href="{{ route('search.index', ['q' => $query, 'type' => 'all']) }}"
-                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'all' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
+                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'all' ? 'bg-emerald-100 text-emerald-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
                                         <span>Все результаты</span>
-                                        <span class="text-xs {{ $type === 'all' ? 'text-indigo-600' : 'text-gray-400' }}">
+                                        <span class="text-xs {{ $type === 'all' ? 'text-emerald-600' : 'text-gray-400' }}">
                                             {{ $counts['users'] + $counts['companies'] + $counts['projects'] + $counts['rfqs'] + $counts['auctions'] }}
                                         </span>
                                     </a>
                                     <a href="{{ route('search.index', ['q' => $query, 'type' => 'companies']) }}"
-                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'companies' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
+                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'companies' ? 'bg-emerald-100 text-emerald-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
                                         <span>Компании</span>
-                                        <span class="text-xs {{ $type === 'companies' ? 'text-indigo-600' : 'text-gray-400' }}">{{ $counts['companies'] }}</span>
+                                        <span class="text-xs {{ $type === 'companies' ? 'text-emerald-600' : 'text-gray-400' }}">{{ $counts['companies'] }}</span>
                                     </a>
                                     <a href="{{ route('search.index', ['q' => $query, 'type' => 'projects']) }}"
-                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'projects' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
+                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'projects' ? 'bg-emerald-100 text-emerald-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
                                         <span>Проекты</span>
-                                        <span class="text-xs {{ $type === 'projects' ? 'text-indigo-600' : 'text-gray-400' }}">{{ $counts['projects'] }}</span>
+                                        <span class="text-xs {{ $type === 'projects' ? 'text-emerald-600' : 'text-gray-400' }}">{{ $counts['projects'] }}</span>
                                     </a>
                                     <a href="{{ route('search.index', ['q' => $query, 'type' => 'rfqs']) }}"
-                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'rfqs' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
+                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'rfqs' ? 'bg-emerald-100 text-emerald-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
                                         <span>Запросы котировок</span>
-                                        <span class="text-xs {{ $type === 'rfqs' ? 'text-indigo-600' : 'text-gray-400' }}">{{ $counts['rfqs'] }}</span>
+                                        <span class="text-xs {{ $type === 'rfqs' ? 'text-emerald-600' : 'text-gray-400' }}">{{ $counts['rfqs'] }}</span>
                                     </a>
                                     <a href="{{ route('search.index', ['q' => $query, 'type' => 'auctions']) }}"
-                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'auctions' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
+                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'auctions' ? 'bg-emerald-100 text-emerald-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
                                         <span>Аукционы</span>
-                                        <span class="text-xs {{ $type === 'auctions' ? 'text-indigo-600' : 'text-gray-400' }}">{{ $counts['auctions'] }}</span>
+                                        <span class="text-xs {{ $type === 'auctions' ? 'text-emerald-600' : 'text-gray-400' }}">{{ $counts['auctions'] }}</span>
                                     </a>
                                     <a href="{{ route('search.index', ['q' => $query, 'type' => 'users']) }}"
-                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'users' ? 'bg-indigo-100 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
+                                       class="flex items-center justify-between px-3 py-2 rounded-md text-sm {{ $type === 'users' ? 'bg-emerald-100 text-emerald-700 font-medium' : 'text-gray-600 hover:bg-gray-100' }}">
                                         <span>Пользователи</span>
-                                        <span class="text-xs {{ $type === 'users' ? 'text-indigo-600' : 'text-gray-400' }}">{{ $counts['users'] }}</span>
+                                        <span class="text-xs {{ $type === 'users' ? 'text-emerald-600' : 'text-gray-400' }}">{{ $counts['users'] }}</span>
                                     </a>
                                 </nav>
                             </div>
@@ -102,7 +102,7 @@
 
                                     <div class="space-y-4">
                                         @foreach($results as $result)
-                                            <a href="{{ $result['url'] }}" class="block p-4 rounded-lg border border-gray-200 hover:border-indigo-300 hover:bg-indigo-50 transition-colors duration-150">
+                                            <a href="{{ $result['url'] }}" class="block p-4 rounded-lg border border-gray-200 hover:border-emerald-300 hover:bg-emerald-50 transition-colors duration-150">
                                                 <div class="flex items-start gap-4">
                                                     <!-- Иконка типа -->
                                                     <div class="flex-shrink-0">
@@ -115,8 +115,8 @@
                                                                 </div>
                                                                 @break
                                                             @case('company')
-                                                                <div class="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center">
-                                                                    <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                <div class="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center">
+                                                                    <svg class="w-5 h-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"></path>
                                                                     </svg>
                                                                 </div>
@@ -152,7 +152,7 @@
                                                                 {{ $result['title'] }}
                                                             </h4>
                                                             @if(isset($result['is_verified']) && $result['is_verified'])
-                                                                <svg class="w-4 h-4 text-blue-500" fill="currentColor" viewBox="0 0 20 20">
+                                                                <svg class="w-4 h-4 text-emerald-500" fill="currentColor" viewBox="0 0 20 20">
                                                                     <path fill-rule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
                                                                 </svg>
                                                             @endif

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unicons.iconscout.com/release/v4.0.0/css/line.css">
     
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="https://bizzio.ru/css/custom.css">
+    <link rel="stylesheet" href="{{ asset('css/custom.css') }}">
 
     <!-- Favicon – современный минимальный набор 2025–2026 -->
     <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('images/favicon-32x32.png') }}">
@@ -285,6 +285,6 @@
     </div>
 
     <!-- Custom JS -->
-    <script src="https://bizzio.ru/js/custom.js"></script>
+    <script src="{{ asset('js/custom.js') }}"></script>
 </body>
 </html>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,21 @@ export default {
             fontFamily: {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
             },
+            colors: {
+                bizzio: {
+                    50: '#ecfdf5',
+                    100: '#d1fae5',
+                    200: '#a7f3d0',
+                    300: '#6ee7b7',
+                    400: '#34d399',
+                    500: '#28a745',  // Primary brand green
+                    600: '#22963e',
+                    700: '#1e8537',
+                    800: '#166534',
+                    900: '#14532d',
+                    950: '#052e16',
+                },
+            },
         },
     },
 


### PR DESCRIPTION
## Summary
- Complete visual rebrand from blue/indigo to green color scheme
- New Bizzio brand color: **#28a745** (green)

## Changes

### Tailwind Config
Added `bizzio` color palette with 11 shades (50-950)

### Updated Components (50 files)
- **Buttons**: `bg-indigo-*` → `bg-bizzio-*` / `bg-emerald-*`
- **Links**: `text-indigo-*` → `text-bizzio-*`
- **Cards**: borders, badges, icons
- **Navigation**: active states, hover effects
- **Forms**: focus rings, inputs
- **Custom CSS**: hero section, features block

## Visual Changes
| Element | Before | After |
|---------|--------|-------|
| Primary color | #4169E1 (blue) | #28a745 (green) |
| Buttons | indigo-600 | bizzio-500/emerald-600 |
| Links | indigo-600 | bizzio-600 |
| Focus rings | indigo-500 | bizzio-500 |

## Test plan
- [ ] Check all pages for consistent green styling
- [ ] Verify buttons, links, and form elements
- [ ] Check mobile responsive views

🤖 Generated with [Claude Code](https://claude.com/claude-code)