### PR TITLE
fix: enable supervisorctl in container

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,5 +1,17 @@
 [supervisord]
 nodaemon=true
+logfile=/var/log/supervisord.log
+pidfile=/run/supervisord.pid
+
+[unix_http_server]
+file=/run/supervisord.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///run/supervisord.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:php-fpm]
 command=/usr/local/sbin/php-fpm -F


### PR DESCRIPTION
## Summary
Fix `supervisorctl status` command not working inside container.

## Changes
Added to `docker/supervisord.conf`:
- `[unix_http_server]` - creates socket at `/run/supervisord.sock`
- `[supervisorctl]` - configures client to use socket
- `[rpcinterface:supervisor]` - enables RPC interface

## After deploy
```bash
docker compose up -d --build
docker compose exec app supervisorctl status
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)