### PR TITLE
feat: switch email from Unisender to Beget SMTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,9 +79,11 @@ YANDEX_CLIENT_ID=
 YANDEX_CLIENT_SECRET=
 YANDEX_REDIRECT_URI=${APP_URL}/auth/yandex/callback
 
-# ===== EMAIL (Unisender Go SMTP) =====
+# ===== EMAIL (Beget SMTP) =====
+# Create mailbox at Beget panel: https://cp.beget.com/mail
+# IMPORTANT: MAIL_FROM_ADDRESS must match MAIL_USERNAME (Beget requirement)
 MAIL_MAILER=smtp
-MAIL_HOST=go1.unisender.ru
+MAIL_HOST=smtp.beget.com
 MAIL_PORT=465
 MAIL_USERNAME=
 MAIL_PASSWORD=

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -4,6 +4,25 @@
 
 ---
 
+## 04.02.2026
+
+### Переключение почты Unisender → Beget SMTP
+
+- `.env.example`: SMTP-настройки заменены на Beget (`smtp.beget.com:465`, SSL)
+- `.env`: хост, логин и параметры обновлены для Beget
+- Важно: Beget требует совпадения MAIL_FROM_ADDRESS с MAIL_USERNAME
+
+**Файлы:** .env.example, .env
+
+### Фикс: class_exists() для Socialite в AppServiceProvider
+
+- Обёрнута регистрация Yandex Socialite в `class_exists()` — предотвращает fatal error при `composer install` когда пакет ещё не установлен
+- Убраны `use` импорты для `SocialiteProviders\*` — заменены на строковые литералы
+
+**Файлы:** app/Providers/AppServiceProvider.php
+
+---
+
 ## 03.02.2026
 
 ### Замена авторизации VK → Яндекс OAuth


### PR DESCRIPTION
## Summary
- Replaced Unisender Go SMTP settings with Beget (`smtp.beget.com:465/SSL`) in `.env.example`
- Updated `CHANGELOG_CLAUDE.md` with Beget SMTP switch and Socialite `class_exists()` fix entries

## Notes
- Beget requires `MAIL_FROM_ADDRESS` to match `MAIL_USERNAME`
- `.env` on server needs manual update with Beget mailbox password
- Recommended: configure SPF/DKIM DNS records for `bizzio.ru`

🤖 Generated with [Claude Code](https://claude.com/claude-code)