### PR TITLE
feat: G7 (#58) — реструктуризация меню «Тендеры» → «Закупки»

### DIFF
--- a/app/Http/Controllers/Auth/SocialiteController.php
+++ b/app/Http/Controllers/Auth/SocialiteController.php
@@ -74,6 +74,6 @@ class SocialiteController extends Controller
         // Входим в систему
         Auth::login($user, true);
 
-        return redirect()->intended('/companies');
+        return redirect()->intended(route('dashboard'));
     }
 }

--- a/app/Http/Controllers/CompanyController.php
+++ b/app/Http/Controllers/CompanyController.php
@@ -41,7 +41,11 @@ class CompanyController extends Controller
         $companies = $query->paginate(20);
         $industries = Industry::orderBy('name')->get();
 
-        return view('companies.index', compact('companies', 'industries'));
+        $pendingJoinRequests = auth()->check()
+            ? auth()->user()->companyJoinRequests()->with('company')->where('status', 'pending')->get()
+            : null;
+
+        return view('companies.index', compact('companies', 'industries', 'pendingJoinRequests'));
     }
 
     /**

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -4,6 +4,21 @@
 
 ---
 
+## 2026-02-21 — G7 (#58): Изменение структуры меню
+
+**Задача:** Реструктуризация навигации — «Тендеры» → «Закупки», Dashboard как главная, перенос «Мои запросы» на страницу компаний.
+
+**Изменённые файлы:**
+- `resources/views/layouts/navigation.blade.php` — Logo ведёт на dashboard (auth) / welcome (guest); убран пункт «Dashboard» из навбара; dropdown «Тендеры» → «Закупки» с новой структурой (Найти закупку, Мои заявки, Мои приглашения, Мои закупки, Создать запрос цен, Создать аукцион, Правила проведения); убран «Мои запросы на присоединение»; добавлена «Лента активности» в user dropdown; зеркальные изменения в мобильном меню
+- `routes/web.php` — `/` для auth-пользователей редиректит на dashboard
+- `app/Http/Controllers/CompanyController.php` — `index()` передаёт `$pendingJoinRequests` во view
+- `resources/views/companies/index.blade.php` — Amber-блок ожидающих запросов на присоединение сверху страницы
+- `app/Http/Controllers/Auth/SocialiteController.php` — OAuth redirect → dashboard вместо /companies
+
+**Тесты:** 185 passed (377 assertions) — все тесты проходят.
+
+---
+
 ## 2026-02-17 (сессия 4) — Выполнение бэклога: 7 задач
 
 ### A14 — Удалить примечание о торгах

--- a/resources/views/companies/index.blade.php
+++ b/resources/views/companies/index.blade.php
@@ -22,6 +22,44 @@
             @endauth
         </div>
 
+        <!-- Ожидающие запросы на присоединение -->
+        @auth
+            @if($pendingJoinRequests && $pendingJoinRequests->count() > 0)
+                <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6">
+                    <div class="flex items-center mb-3">
+                        <svg class="w-5 h-5 text-amber-600 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                        </svg>
+                        <h3 class="text-sm font-semibold text-amber-800">{{ __('Ожидающие запросы на присоединение') }}</h3>
+                    </div>
+                    <div class="space-y-2">
+                        @foreach($pendingJoinRequests as $joinRequest)
+                            <div class="flex items-center justify-between bg-white rounded-md px-3 py-2 border border-amber-100">
+                                <div class="flex items-center space-x-3">
+                                    <a href="{{ route('companies.show', $joinRequest->company) }}" class="text-sm font-medium text-emerald-600 hover:text-emerald-800">
+                                        {{ $joinRequest->company->name }}
+                                    </a>
+                                    <span class="text-xs text-gray-500">{{ $joinRequest->created_at->diffForHumans() }}</span>
+                                </div>
+                                <form method="POST" action="{{ route('join-requests.destroy', $joinRequest) }}">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="text-xs text-red-600 hover:text-red-800 font-medium">
+                                        {{ __('Отозвать') }}
+                                    </button>
+                                </form>
+                            </div>
+                        @endforeach
+                    </div>
+                    <div class="mt-3">
+                        <a href="{{ route('join-requests.index') }}" class="text-xs text-amber-700 hover:text-amber-900 font-medium">
+                            {{ __('Все запросы') }} &rarr;
+                        </a>
+                    </div>
+                </div>
+            @endif
+        @endauth
+
         <!-- Фильтры -->
         <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg mb-6">
             <div class="p-6">

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -5,20 +5,13 @@
             <div class="flex">
                 <!-- Logo -->
                 <div class="shrink-0 flex items-center">
-                    <a href="{{ url('/') }}">
+                    <a href="{{ auth()->check() ? route('dashboard') : url('/') }}">
                         <img src="{{ asset('images/apple-touch-icon.png') }}" alt="Icon" class="reduce-10 h-10 w-auto max-h-12 object-contain">
                     </a>
                 </div>
 
                 <!-- Navigation Links (Desktop) -->
                 <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
-                    <!-- Dashboard -->
-                    @auth
-                    <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                        {{ __('Dashboard') }}
-                    </x-nav-link>
-                    @endauth
-
                     <!-- Компании -->
                     <x-nav-link :href="route('companies.index')" :active="request()->routeIs('companies.*')">
                         {{ __('Компании') }}
@@ -29,13 +22,13 @@
                         {{ __('Проекты') }}
                     </x-nav-link>
                     
-                    <!-- Тендеры (Dropdown) -->
+                    <!-- Закупки (Dropdown) -->
                     <div class="hidden sm:flex sm:items-center sm:ms-6">
                         <div class="relative" x-data="{ open: false }">
                             <button @click="open = ! open"
                                     class="inline-flex items-center px-1 pt-1 text-sm font-medium leading-5 transition duration-150 ease-in-out border-b-2
                                         {{ request()->routeIs('tenders.*', 'rfqs.*', 'auctions.*', 'bids.*', 'invitations.*') ? 'border-emerald-400 text-gray-900 focus:border-emerald-700' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 focus:text-gray-700 focus:border-gray-300' }}">
-                                <span>{{ __('Тендеры') }}</span>
+                                <span>{{ __('Закупки') }}</span>
                                 <svg class="ml-2 -mr-0.5 h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
                                     <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
                                 </svg>
@@ -48,36 +41,33 @@
                                 style="display: none;">
                                 <div class="py-1">
                                     <a href="{{ route('tenders.index') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
-                                        {{ __('Найти тендер') }}
-                                    </a>
-                                    <a href="{{ route('tenders.rules') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
-                                        {{ __('Правила проведения') }}
+                                        {{ __('Найти закупку') }}
                                     </a>
                                     @auth
-                                        @if(auth()->user()->isModeratorOfAnyCompany())
-                                            <div class="border-t border-gray-100"></div>
-                                            <a href="{{ route('rfqs.create') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
-                                                {{ __('Разместить Запрос цен') }}
-                                            </a>
-                                            <a href="{{ route('auctions.create') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
-                                                {{ __('Разместить аукцион') }}
-                                            </a>
-                                        @endif
                                         <div class="border-t border-gray-100"></div>
-                                        <a href="{{ route('tenders.my') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
-                                            {{ __('Мои тендеры') }}
-                                        </a>
                                         <a href="{{ route('tenders.bids.my') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                                             {{ __('Мои заявки') }}
                                         </a>
                                         <a href="{{ route('tenders.invitations.my') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                                             {{ __('Мои приглашения') }}
                                         </a>
-                                        <div class="border-t border-gray-100"></div>
-                                        <a href="{{ route('join-requests.index') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
-                                            {{ __('Мои запросы на присоединение') }}
-                                        </a>
+                                        @if(auth()->user()->isModeratorOfAnyCompany())
+                                            <div class="border-t border-gray-100"></div>
+                                            <a href="{{ route('tenders.my') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                                                {{ __('Мои закупки') }}
+                                            </a>
+                                            <a href="{{ route('rfqs.create') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                                                {{ __('Создать запрос цен') }}
+                                            </a>
+                                            <a href="{{ route('auctions.create') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                                                {{ __('Создать аукцион') }}
+                                            </a>
+                                        @endif
                                     @endauth
+                                    <div class="border-t border-gray-100"></div>
+                                    <a href="{{ route('tenders.rules') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                                        {{ __('Правила проведения') }}
+                                    </a>
                                 </div>
                             </div>
                         </div>
@@ -269,6 +259,10 @@
                                 {{ __('Профиль') }}
                             </x-dropdown-link>
 
+                            <x-dropdown-link :href="route('dashboard')">
+                                {{ __('Лента активности') }}
+                            </x-dropdown-link>
+
                             <!-- Authentication -->
                             <form method="POST" action="{{ route('logout') }}">
                                 @csrf
@@ -308,11 +302,6 @@
     {{-- G3: Добавлен скролл для длинного мобильного меню --}}
     <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden max-h-[calc(100vh-4rem)] overflow-y-auto">
         <div class="pt-2 pb-3 space-y-1">
-            <!-- Dashboard -->
-            <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                {{ __('Dashboard') }}
-            </x-responsive-nav-link>
-
             <!-- Компании -->
             <x-responsive-nav-link :href="route('companies.index')" :active="request()->routeIs('companies.*')">
                 {{ __('Компании') }}
@@ -323,38 +312,18 @@
                 {{ __('Проекты') }}
             </x-responsive-nav-link>
 
-            <!-- Тендеры -->
+            <!-- Закупки -->
             <div class="border-t border-gray-200 pt-2 mt-2">
                 <div class="px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                    {{ __('Тендеры') }}
+                    {{ __('Закупки') }}
                 </div>
 
                 <x-responsive-nav-link :href="route('tenders.index')" :active="request()->routeIs('tenders.index')">
-                    {{ __('Найти тендер') }}
-                </x-responsive-nav-link>
-
-                <x-responsive-nav-link :href="route('tenders.rules')" :active="request()->routeIs('tenders.rules')">
-                    {{ __('Правила проведения') }}
+                    {{ __('Найти закупку') }}
                 </x-responsive-nav-link>
 
                 @auth
-                    @if(auth()->user()->isModeratorOfAnyCompany())
-                        <div class="border-t border-gray-100 my-2"></div>
-
-                        <x-responsive-nav-link :href="route('rfqs.create')" :active="request()->routeIs('rfqs.create')">
-                            {{ __('Разместить Запрос цен') }}
-                        </x-responsive-nav-link>
-
-                        <x-responsive-nav-link :href="route('auctions.create')" :active="request()->routeIs('auctions.create')">
-                            {{ __('Разместить аукцион') }}
-                        </x-responsive-nav-link>
-                    @endif
-
                     <div class="border-t border-gray-100 my-2"></div>
-
-                    <x-responsive-nav-link :href="route('tenders.my')" :active="request()->routeIs('tenders.my')">
-                        {{ __('Мои тендеры') }}
-                    </x-responsive-nav-link>
 
                     <x-responsive-nav-link :href="route('tenders.bids.my')" :active="request()->routeIs('tenders.bids.my')">
                         {{ __('Мои заявки') }}
@@ -364,12 +333,28 @@
                         {{ __('Мои приглашения') }}
                     </x-responsive-nav-link>
 
-                    <div class="border-t border-gray-100 my-2"></div>
+                    @if(auth()->user()->isModeratorOfAnyCompany())
+                        <div class="border-t border-gray-100 my-2"></div>
 
-                    <x-responsive-nav-link :href="route('join-requests.index')" :active="request()->routeIs('join-requests.index')">
-                        {{ __('Мои запросы на присоединение') }}
-                    </x-responsive-nav-link>
+                        <x-responsive-nav-link :href="route('tenders.my')" :active="request()->routeIs('tenders.my')">
+                            {{ __('Мои закупки') }}
+                        </x-responsive-nav-link>
+
+                        <x-responsive-nav-link :href="route('rfqs.create')" :active="request()->routeIs('rfqs.create')">
+                            {{ __('Создать запрос цен') }}
+                        </x-responsive-nav-link>
+
+                        <x-responsive-nav-link :href="route('auctions.create')" :active="request()->routeIs('auctions.create')">
+                            {{ __('Создать аукцион') }}
+                        </x-responsive-nav-link>
+                    @endif
                 @endauth
+
+                <div class="border-t border-gray-100 my-2"></div>
+
+                <x-responsive-nav-link :href="route('tenders.rules')" :active="request()->routeIs('tenders.rules')">
+                    {{ __('Правила проведения') }}
+                </x-responsive-nav-link>
             </div>
 
             <!-- Новости -->
@@ -401,6 +386,10 @@
                 <div class="mt-3 space-y-1">
                     <x-responsive-nav-link :href="route('profile.edit')">
                         {{ __('Профиль') }}
+                    </x-responsive-nav-link>
+
+                    <x-responsive-nav-link :href="route('dashboard')">
+                        {{ __('Лента активности') }}
                     </x-responsive-nav-link>
 
                     <!-- Authentication -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,9 @@ use App\Http\Controllers\TenderController;
 */
 
 Route::get('/', function () {
+    if (auth()->check()) {
+        return redirect()->route('dashboard');
+    }
     return view('welcome');
 });
 


### PR DESCRIPTION
## Summary
- Logo ведёт на dashboard (auth) / welcome (guest)
- Убран «Dashboard» из навбара, добавлена «Лента активности» в user dropdown
- Dropdown «Тендеры» → «Закупки» с ролевым разделением (public / auth / moderator)
- «Мои запросы на присоединение» убраны из меню, перенесены на `/companies` (amber-блок)
- `/` редирект на dashboard для авторизованных
- OAuth redirect → dashboard вместо /companies

## Test plan
- [x] 185 тестов проходят (377 assertions)
- [ ] `/` (guest) → welcome page
- [ ] `/` (auth) → redirect на dashboard
- [ ] Logo → dashboard (auth), welcome (guest)
- [ ] «Закупки» dropdown: пункты по ролям
- [ ] «Мои запросы» нет в меню, есть на `/companies`
- [ ] User dropdown: Профиль, Лента активности, Выйти
- [ ] Мобильное меню: те же изменения

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)