### PR TITLE
feat: #60 — новая главная страница (dashboard)

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,29 +2,151 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Auction;
+use App\Models\AuctionBid;
+use App\Models\AuctionInvitation;
+use App\Models\News;
+use App\Models\Post;
+use App\Models\Project;
+use App\Models\Rfq;
+use App\Models\RfqBid;
+use App\Models\RfqInvitation;
 use Illuminate\Http\Request;
 use Spatie\Activitylog\Models\Activity;
 
 class DashboardController extends Controller
 {
-    /**
-     * Display the dashboard with activity feed.
-     */
     public function index()
     {
+        $user = auth()->user();
+
+        // Компании пользователя (один запрос для всех виджетов)
+        $userCompanies = $user->moderatedCompanies()->get();
+        $companyIds = $userCompanies->pluck('id');
+
+        // === Левая колонка ===
+        $pendingJoinRequests = $user->pendingCompanyRequests()
+            ->with('company')
+            ->latest()
+            ->take(1)
+            ->get();
+
+        $userProjects = Project::where(function ($q) use ($companyIds) {
+            $q->whereIn('company_id', $companyIds)
+                ->orWhereHas('participants', fn ($q2) => $q2->whereIn('companies.id', $companyIds));
+        })
+            ->latest()
+            ->take(10)
+            ->get();
+
+        // === Центральная колонка ===
+        $keywords = $user->keywords()->pluck('keyword')->toArray();
+        $latestNews = News::query()
+            ->when(! empty($keywords), fn ($q) => $q->searchByKeywords($keywords, 'any'))
+            ->latest('published_at')
+            ->take(3)
+            ->get();
+
+        $recentPosts = Post::with(['user', 'media'])
+            ->latest()
+            ->take(10)
+            ->get();
+
         $activities = Activity::with(['causer', 'subject'])
             ->latest()
             ->take(20)
             ->get();
 
-        $unreadNotificationsCount = auth()->user()->unreadNotifications()->count();
+        // === Правая колонка ===
+        $myRfqs = Rfq::whereIn('company_id', $companyIds)
+            ->latest()
+            ->take(3)
+            ->get();
 
-        return view('dashboard', compact('activities', 'unreadNotificationsCount'));
+        $myAuctions = Auction::whereIn('company_id', $companyIds)
+            ->latest()
+            ->take(3)
+            ->get();
+
+        $myTenders = $myRfqs->map(fn ($r) => [
+            'type' => 'rfq',
+            'title' => $r->title,
+            'number' => $r->number,
+            'status' => $r->status,
+            'url' => route('rfqs.show', $r),
+        ])->merge($myAuctions->map(fn ($a) => [
+            'type' => 'auction',
+            'title' => $a->title,
+            'number' => $a->number,
+            'status' => $a->status,
+            'url' => route('auctions.show', $a),
+        ]))->sortByDesc('number')->take(3)->values();
+
+        $rfqInvitations = RfqInvitation::whereIn('company_id', $companyIds)
+            ->with('rfq')
+            ->latest()
+            ->take(3)
+            ->get();
+
+        $auctionInvitations = AuctionInvitation::whereIn('company_id', $companyIds)
+            ->with('auction')
+            ->latest()
+            ->take(3)
+            ->get();
+
+        $myInvitations = $rfqInvitations->map(fn ($i) => [
+            'type' => 'rfq',
+            'title' => $i->rfq->title ?? '',
+            'number' => $i->rfq->number ?? '',
+            'status' => $i->status,
+            'url' => route('rfqs.show', $i->rfq_id),
+        ])->merge($auctionInvitations->map(fn ($i) => [
+            'type' => 'auction',
+            'title' => $i->auction->title ?? '',
+            'number' => $i->auction->number ?? '',
+            'status' => $i->status,
+            'url' => route('auctions.show', $i->auction_id),
+        ]))->take(3)->values();
+
+        $rfqBids = RfqBid::whereIn('company_id', $companyIds)
+            ->with('rfq')
+            ->latest()
+            ->take(3)
+            ->get();
+
+        $auctionBids = AuctionBid::whereIn('company_id', $companyIds)
+            ->with('auction')
+            ->latest()
+            ->take(3)
+            ->get();
+
+        $myBids = $rfqBids->map(fn ($b) => [
+            'type' => 'rfq',
+            'title' => $b->rfq->title ?? '',
+            'number' => $b->rfq->number ?? '',
+            'price' => $b->price,
+            'url' => route('rfqs.show', $b->rfq_id),
+        ])->merge($auctionBids->map(fn ($b) => [
+            'type' => 'auction',
+            'title' => $b->auction->title ?? '',
+            'number' => $b->auction->number ?? '',
+            'price' => $b->price,
+            'url' => route('auctions.show', $b->auction_id),
+        ]))->take(3)->values();
+
+        return view('dashboard', compact(
+            'userCompanies',
+            'pendingJoinRequests',
+            'userProjects',
+            'latestNews',
+            'recentPosts',
+            'activities',
+            'myTenders',
+            'myInvitations',
+            'myBids',
+        ));
     }
 
-    /**
-     * Load more activities (AJAX).
-     */
     public function loadMoreActivities(Request $request)
     {
         $offset = $request->input('offset', 0);

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use Illuminate\Http\Request;
+
+class PostController extends Controller
+{
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'body' => ['required', 'string', 'max:2000'],
+            'photo' => ['nullable', 'image', 'max:5120'],
+        ]);
+
+        $post = Post::create([
+            'user_id' => $request->user()->id,
+            'body' => $validated['body'],
+        ]);
+
+        if ($request->hasFile('photo')) {
+            $post->addMediaFromRequest('photo')->toMediaCollection('photos');
+        }
+
+        return redirect()->route('dashboard')->with('success', 'Пост опубликован');
+    }
+
+    public function destroy(Post $post)
+    {
+        abort_unless($post->user_id === auth()->id(), 403);
+
+        $post->delete();
+
+        return redirect()->route('dashboard')->with('success', 'Пост удалён');
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+
+class Post extends Model implements HasMedia
+{
+    use HasFactory, InteractsWithMedia, LogsActivity, SoftDeletes;
+
+    protected $fillable = [
+        'user_id',
+        'body',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('photos')
+            ->useDisk('public')
+            ->acceptsMimeTypes(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+    }
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['body'])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs()
+            ->setDescriptionForEvent(fn (string $eventName) => match ($eventName) {
+                'created' => 'создал(а) пост',
+                'updated' => 'обновил(а) пост',
+                'deleted' => 'удалил(а) пост',
+                default => $eventName,
+            });
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -99,7 +99,7 @@ class User extends Orchid
     public function moderatedCompanies(): BelongsToMany
     {
         return $this->belongsToMany(Company::class, 'company_user')
-            ->select('companies.id', 'companies.name', 'companies.inn', 'companies.is_verified') // ⚠️ ЯВНО указываем поля
+            ->select('companies.id', 'companies.name', 'companies.slug', 'companies.inn', 'companies.is_verified') // ⚠️ ЯВНО указываем поля
         ->withPivot(['role', 'added_by', 'added_at', 'can_manage_moderators'])
         ->withTimestamps();
     }

--- a/database/migrations/2026_02_21_100000_create_posts_table.php
+++ b/database/migrations/2026_02_21_100000_create_posts_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->text('body');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('posts');
+    }
+};

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -4,6 +4,37 @@
 
 ---
 
+## 2026-02-21 — #60: Новая главная страница (dashboard)
+
+**Задача:** Полноценный 3-колоночный dashboard с профилем, новостями, постами, закупками, заявками и приглашениями.
+
+**Новые файлы:**
+- `database/migrations/2026_02_21_100000_create_posts_table.php` — миграция таблицы постов
+- `app/Models/Post.php` — модель поста (SoftDeletes, InteractsWithMedia, LogsActivity)
+- `app/Http/Controllers/PostController.php` — store/destroy для постов
+- `resources/views/partials/dashboard/profile-card.blade.php` — карточка профиля
+- `resources/views/partials/dashboard/join-requests-widget.blade.php` — виджет заявок на вступление
+- `resources/views/partials/dashboard/my-companies-widget.blade.php` — список компаний пользователя
+- `resources/views/partials/dashboard/my-projects-widget.blade.php` — список проектов
+- `resources/views/partials/dashboard/news-widget.blade.php` — 3 последние новости
+- `resources/views/partials/dashboard/post-form.blade.php` — форма создания поста (Alpine.js preview)
+- `resources/views/partials/dashboard/posts-feed.blade.php` — лента постов
+- `resources/views/partials/dashboard/activity-feed.blade.php` — лента активности + load more
+- `resources/views/partials/dashboard/tenders-widget.blade.php` — виджет закупок
+- `resources/views/partials/dashboard/invitations-widget.blade.php` — виджет приглашений
+- `resources/views/partials/dashboard/bids-widget.blade.php` — виджет заявок
+
+**Изменённые файлы:**
+- `app/Models/User.php` — добавлен `companies.slug` в `moderatedCompanies()` select
+- `app/Http/Controllers/DashboardController.php` — полностью переписан `index()`: 3 колонки данных
+- `resources/views/dashboard.blade.php` — 3-колоночный layout (grid-cols-5: 1+3+1)
+- `routes/web.php` — добавлены роуты POST /posts и DELETE /posts/{post}
+- `tests/Feature/DashboardTest.php` — обновлены существующие + добавлены тесты постов и view data
+
+**Тесты:** 192 passed (401 assertions) — все тесты проходят.
+
+---
+
 ## 2026-02-21 — G7 (#58): Изменение структуры меню
 
 **Задача:** Реструктуризация навигации — «Тендеры» → «Закупки», Dashboard как главная, перенос «Мои запросы» на страницу компаний.

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -7,130 +7,31 @@
 
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            <div class="grid grid-cols-1 lg:grid-cols-5 gap-6">
 
-                <!-- Основная колонка: Лента активности -->
-                <div class="lg:col-span-2">
-                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                        <div class="p-6">
-                            <h3 class="text-lg font-semibold text-gray-900 mb-4">
-                                {{ __('Лента активности') }}
-                            </h3>
-
-                            <div id="activity-feed" class="space-y-4">
-                                @include('partials.activity-items', ['activities' => $activities])
-                            </div>
-
-                            @if($activities->count() >= 20)
-                                <div class="mt-6 text-center">
-                                    <button
-                                        id="load-more-btn"
-                                        data-offset="20"
-                                        class="inline-flex items-center px-4 py-2 bg-gray-100 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-200 focus:bg-gray-200 active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150"
-                                    >
-                                        <span id="load-more-text">{{ __('Загрузить ещё') }}</span>
-                                        <svg id="load-more-spinner" class="hidden animate-spin ml-2 h-4 w-4 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                                        </svg>
-                                    </button>
-                                </div>
-                            @endif
-                        </div>
-                    </div>
+                {{-- Левая колонка --}}
+                <div class="lg:col-span-1 space-y-4">
+                    @include('partials.dashboard.profile-card')
+                    @include('partials.dashboard.join-requests-widget')
+                    @include('partials.dashboard.my-companies-widget')
+                    @include('partials.dashboard.my-projects-widget')
                 </div>
 
-                <!-- Боковая колонка: Уведомления -->
-                <div class="lg:col-span-1">
-                    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                        <div class="p-6">
-                            <div class="flex items-center justify-between mb-4">
-                                <h3 class="text-lg font-semibold text-gray-900">
-                                    {{ __('Уведомления') }}
-                                </h3>
-                                @if($unreadNotificationsCount > 0)
-                                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
-                                        {{ $unreadNotificationsCount }}
-                                    </span>
-                                @endif
-                            </div>
-
-                            @php
-                                $notifications = auth()->user()->notifications()->latest()->take(5)->get();
-                            @endphp
-
-                            @if($notifications->isEmpty())
-                                <p class="text-gray-500 text-sm">{{ __('Нет уведомлений') }}</p>
-                            @else
-                                <div class="space-y-3">
-                                    @foreach($notifications as $notification)
-                                        <div class="flex items-start space-x-3 p-3 rounded-lg {{ $notification->read_at ? 'bg-gray-50' : 'bg-emerald-50' }}">
-                                            <div class="flex-shrink-0">
-                                                @switch($notification->data['type'] ?? '')
-                                                    @case('project_invitation')
-                                                        <svg class="h-5 w-5 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"></path>
-                                                        </svg>
-                                                        @break
-                                                    @case('tender_invitation')
-                                                        <svg class="h-5 w-5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
-                                                        </svg>
-                                                        @break
-                                                    @case('tender_closed')
-                                                        <svg class="h-5 w-5 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                                        </svg>
-                                                        @break
-                                                    @case('new_comment')
-                                                        <svg class="h-5 w-5 text-purple-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"></path>
-                                                        </svg>
-                                                        @break
-                                                    @default
-                                                        <svg class="h-5 w-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path>
-                                                        </svg>
-                                                @endswitch
-                                            </div>
-                                            <div class="flex-1 min-w-0">
-                                                @if(isset($notification->data['url']))
-                                                    <a href="{{ $notification->data['url'] }}" class="text-sm font-medium text-gray-900 hover:text-emerald-600">
-                                                        @include('partials.notification-text', ['notification' => $notification])
-                                                    </a>
-                                                @else
-                                                    <p class="text-sm font-medium text-gray-900">
-                                                        @include('partials.notification-text', ['notification' => $notification])
-                                                    </p>
-                                                @endif
-                                                <p class="text-xs text-gray-500 mt-1">
-                                                    {{ $notification->created_at->diffForHumans() }}
-                                                </p>
-                                            </div>
-                                        </div>
-                                    @endforeach
-                                </div>
-
-                                @if($unreadNotificationsCount > 0)
-                                    <div class="mt-4">
-                                        <button
-                                            id="mark-all-read-btn"
-                                            class="text-sm text-emerald-600 hover:text-emerald-800"
-                                        >
-                                            {{ __('Отметить все как прочитанные') }}
-                                        </button>
-                                    </div>
-                                @endif
-
-                                <div class="mt-4 pt-4 border-t border-gray-200">
-                                    <a href="{{ route('notifications.index') }}" class="text-sm text-emerald-600 hover:text-emerald-800">
-                                        {{ __('Все уведомления') }} &rarr;
-                                    </a>
-                                </div>
-                            @endif
-                        </div>
-                    </div>
+                {{-- Центральная колонка --}}
+                <div class="lg:col-span-3 space-y-6">
+                    @include('partials.dashboard.news-widget')
+                    @include('partials.dashboard.post-form')
+                    @include('partials.dashboard.posts-feed')
+                    @include('partials.dashboard.activity-feed')
                 </div>
+
+                {{-- Правая колонка --}}
+                <div class="lg:col-span-1 space-y-4">
+                    @include('partials.dashboard.tenders-widget')
+                    @include('partials.dashboard.invitations-widget')
+                    @include('partials.dashboard.bids-widget')
+                </div>
+
             </div>
         </div>
     </div>
@@ -138,7 +39,6 @@
     @push('scripts')
     <script>
         document.addEventListener('DOMContentLoaded', function() {
-            // Загрузить ещё активности
             const loadMoreBtn = document.getElementById('load-more-btn');
             if (loadMoreBtn) {
                 loadMoreBtn.addEventListener('click', function() {
@@ -172,50 +72,7 @@
                     });
                 });
             }
-
-            // Отметить все уведомления как прочитанные
-            const markAllReadBtn = document.getElementById('mark-all-read-btn');
-            if (markAllReadBtn) {
-                markAllReadBtn.addEventListener('click', function() {
-                    fetch('{{ route('notifications.read-all') }}', {
-                        method: 'POST',
-                        headers: {
-                            'X-CSRF-TOKEN': '{{ csrf_token() }}',
-                            'X-Requested-With': 'XMLHttpRequest',
-                            'Content-Type': 'application/json'
-                        }
-                    })
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.success) {
-                            // Обновить UI
-                            document.querySelectorAll('.bg-emerald-50').forEach(el => {
-                                el.classList.remove('bg-emerald-50');
-                                el.classList.add('bg-gray-50');
-                            });
-                            // Убрать бейдж и кнопку
-                            const badge = document.querySelector('.bg-red-100');
-                            if (badge) badge.remove();
-                            markAllReadBtn.remove();
-                            // Обновить бейдж в навигации
-                            updateNotificationBadge(0);
-                        }
-                    });
-                });
-            }
         });
-
-        function updateNotificationBadge(count) {
-            const badge = document.getElementById('notification-badge');
-            if (badge) {
-                if (count > 0) {
-                    badge.textContent = count;
-                    badge.classList.remove('hidden');
-                } else {
-                    badge.classList.add('hidden');
-                }
-            }
-        }
     </script>
     @endpush
 </x-app-layout>

--- a/resources/views/partials/dashboard/activity-feed.blade.php
+++ b/resources/views/partials/dashboard/activity-feed.blade.php
@@ -1,0 +1,25 @@
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <div class="p-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-4">{{ __('Лента активности') }}</h3>
+
+        <div id="activity-feed" class="space-y-4">
+            @include('partials.activity-items', ['activities' => $activities])
+        </div>
+
+        @if($activities->count() >= 20)
+            <div class="mt-6 text-center">
+                <button
+                    id="load-more-btn"
+                    data-offset="20"
+                    class="inline-flex items-center px-4 py-2 bg-gray-100 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-gray-200 focus:bg-gray-200 active:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2 transition ease-in-out duration-150"
+                >
+                    <span id="load-more-text">{{ __('Загрузить ещё') }}</span>
+                    <svg id="load-more-spinner" class="hidden animate-spin ml-2 h-4 w-4 text-gray-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                </button>
+            </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/partials/dashboard/bids-widget.blade.php
+++ b/resources/views/partials/dashboard/bids-widget.blade.php
@@ -1,0 +1,27 @@
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <div class="p-4">
+        <h4 class="text-sm font-semibold text-gray-900 mb-3">{{ __('Мои заявки') }}</h4>
+        @if($myBids->isNotEmpty())
+            <ul class="space-y-2">
+                @foreach($myBids as $bid)
+                    <li class="text-sm">
+                        <a href="{{ $bid['url'] }}" class="text-gray-700 hover:text-emerald-600 block truncate">
+                            {{ $bid['title'] ?: $bid['number'] }}
+                        </a>
+                        <div class="flex items-center space-x-2 mt-0.5">
+                            <span class="text-xs px-1.5 py-0.5 rounded {{ $bid['type'] === 'rfq' ? 'bg-yellow-100 text-yellow-800' : 'bg-purple-100 text-purple-800' }}">
+                                {{ $bid['type'] === 'rfq' ? 'ЗЦ' : 'Аукцион' }}
+                            </span>
+                            <span class="text-xs text-gray-500">{{ number_format($bid['price'], 0, ',', ' ') }} ₽</span>
+                        </div>
+                    </li>
+                @endforeach
+            </ul>
+        @else
+            <p class="text-xs text-gray-500">{{ __('Нет заявок') }}</p>
+        @endif
+        <a href="{{ route('tenders.bids.my') }}" class="mt-2 inline-block text-xs text-emerald-600 hover:text-emerald-800">
+            {{ __('Все заявки') }} &rarr;
+        </a>
+    </div>
+</div>

--- a/resources/views/partials/dashboard/invitations-widget.blade.php
+++ b/resources/views/partials/dashboard/invitations-widget.blade.php
@@ -1,0 +1,27 @@
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <div class="p-4">
+        <h4 class="text-sm font-semibold text-gray-900 mb-3">{{ __('Приглашения') }}</h4>
+        @if($myInvitations->isNotEmpty())
+            <ul class="space-y-2">
+                @foreach($myInvitations as $inv)
+                    <li class="text-sm">
+                        <a href="{{ $inv['url'] }}" class="text-gray-700 hover:text-emerald-600 block truncate">
+                            {{ $inv['title'] ?: $inv['number'] }}
+                        </a>
+                        <div class="flex items-center space-x-2 mt-0.5">
+                            <span class="text-xs px-1.5 py-0.5 rounded {{ $inv['type'] === 'rfq' ? 'bg-yellow-100 text-yellow-800' : 'bg-purple-100 text-purple-800' }}">
+                                {{ $inv['type'] === 'rfq' ? 'ЗЦ' : 'Аукцион' }}
+                            </span>
+                            <span class="text-xs text-gray-500">{{ $inv['status'] }}</span>
+                        </div>
+                    </li>
+                @endforeach
+            </ul>
+        @else
+            <p class="text-xs text-gray-500">{{ __('Нет приглашений') }}</p>
+        @endif
+        <a href="{{ route('tenders.invitations.my') }}" class="mt-2 inline-block text-xs text-emerald-600 hover:text-emerald-800">
+            {{ __('Все приглашения') }} &rarr;
+        </a>
+    </div>
+</div>

--- a/resources/views/partials/dashboard/join-requests-widget.blade.php
+++ b/resources/views/partials/dashboard/join-requests-widget.blade.php
@@ -1,0 +1,17 @@
+@if($pendingJoinRequests->isNotEmpty())
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <div class="p-4">
+        <h4 class="text-sm font-semibold text-gray-900 mb-3">{{ __('Заявки на вступление') }}</h4>
+        @foreach($pendingJoinRequests as $request)
+            <div class="flex items-center space-x-2 text-sm">
+                <span class="inline-block w-2 h-2 bg-yellow-400 rounded-full flex-shrink-0"></span>
+                <span class="text-gray-700 truncate">{{ $request->company->name ?? '' }}</span>
+            </div>
+        @endforeach
+        <a href="{{ route('join-requests.index') }}"
+           class="mt-2 inline-block text-xs text-emerald-600 hover:text-emerald-800">
+            {{ __('Все заявки') }} &rarr;
+        </a>
+    </div>
+</div>
+@endif

--- a/resources/views/partials/dashboard/my-companies-widget.blade.php
+++ b/resources/views/partials/dashboard/my-companies-widget.blade.php
@@ -1,0 +1,24 @@
+@if($userCompanies->isNotEmpty())
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <div class="p-4">
+        <h4 class="text-sm font-semibold text-gray-900 mb-3">{{ __('Мои компании') }}</h4>
+        <ul class="space-y-2">
+            @foreach($userCompanies as $company)
+                <li class="flex items-center space-x-2 text-sm">
+                    @if($company->is_verified)
+                        <svg class="w-4 h-4 text-emerald-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                        </svg>
+                    @else
+                        <span class="w-4 h-4 flex-shrink-0"></span>
+                    @endif
+                    <a href="{{ route('companies.show', $company) }}"
+                       class="text-gray-700 hover:text-emerald-600 truncate">
+                        {{ $company->name }}
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+    </div>
+</div>
+@endif

--- a/resources/views/partials/dashboard/my-projects-widget.blade.php
+++ b/resources/views/partials/dashboard/my-projects-widget.blade.php
@@ -1,0 +1,21 @@
+@if($userProjects->isNotEmpty())
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <div class="p-4">
+        <h4 class="text-sm font-semibold text-gray-900 mb-3">{{ __('Мои проекты') }}</h4>
+        <ul class="space-y-2">
+            @foreach($userProjects as $project)
+                <li>
+                    <a href="{{ route('projects.show', ['project' => $project->slug]) }}"
+                       class="text-sm text-gray-700 hover:text-emerald-600 truncate block">
+                        {{ $project->name }}
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+        <a href="{{ route('projects.index') }}"
+           class="mt-2 inline-block text-xs text-emerald-600 hover:text-emerald-800">
+            {{ __('Все проекты') }} &rarr;
+        </a>
+    </div>
+</div>
+@endif

--- a/resources/views/partials/dashboard/news-widget.blade.php
+++ b/resources/views/partials/dashboard/news-widget.blade.php
@@ -1,0 +1,35 @@
+@if($latestNews->isNotEmpty())
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <div class="p-6">
+        <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-semibold text-gray-900">{{ __('Новости') }}</h3>
+            <a href="{{ route('news.index') }}" class="text-sm text-emerald-600 hover:text-emerald-800">
+                {{ __('Все новости') }} &rarr;
+            </a>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            @foreach($latestNews as $news)
+                <a href="{{ $news->link }}" target="_blank" rel="noopener"
+                   class="block group">
+                    @if($news->image)
+                        <img src="{{ $news->image }}" alt=""
+                             class="w-full h-32 object-cover rounded-lg mb-2">
+                    @else
+                        <div class="w-full h-32 bg-gray-100 rounded-lg mb-2 flex items-center justify-center">
+                            <svg class="w-8 h-8 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 20H5a2 2 0 01-2-2V6a2 2 0 012-2h10a2 2 0 012 2v1m2 13a2 2 0 01-2-2V7m2 13a2 2 0 002-2V9a2 2 0 00-2-2h-2m-4-3H9M7 16h6M7 8h6v4H7V8z"/>
+                            </svg>
+                        </div>
+                    @endif
+                    <h4 class="text-sm font-medium text-gray-900 group-hover:text-emerald-600 line-clamp-2">
+                        {{ $news->title }}
+                    </h4>
+                    <p class="text-xs text-gray-500 mt-1">
+                        {{ $news->published_at?->diffForHumans() }}
+                    </p>
+                </a>
+            @endforeach
+        </div>
+    </div>
+</div>
+@endif

--- a/resources/views/partials/dashboard/post-form.blade.php
+++ b/resources/views/partials/dashboard/post-form.blade.php
@@ -1,0 +1,47 @@
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <div class="p-6">
+        <form action="{{ route('posts.store') }}" method="POST" enctype="multipart/form-data"
+              x-data="{ preview: null }">
+            @csrf
+            <div class="flex items-start space-x-3">
+                <img src="{{ auth()->user()->avatar_url }}" alt=""
+                     class="w-10 h-10 rounded-full object-cover flex-shrink-0">
+                <div class="flex-1">
+                    <textarea name="body" rows="2" placeholder="{{ __('Что нового?') }}"
+                              class="w-full border-gray-300 rounded-lg text-sm focus:ring-emerald-500 focus:border-emerald-500 resize-none"
+                              required maxlength="2000">{{ old('body') }}</textarea>
+                    @error('body')
+                        <p class="text-xs text-red-600 mt-1">{{ $message }}</p>
+                    @enderror
+
+                    <template x-if="preview">
+                        <div class="mt-2 relative inline-block">
+                            <img :src="preview" class="h-20 rounded-lg object-cover">
+                            <button type="button" @click="preview = null; $refs.photoInput.value = ''"
+                                    class="absolute -top-1 -right-1 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs">
+                                &times;
+                            </button>
+                        </div>
+                    </template>
+
+                    <div class="mt-2 flex items-center justify-between">
+                        <label class="cursor-pointer text-gray-500 hover:text-emerald-600">
+                            <svg class="w-5 h-5 inline" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                            </svg>
+                            <input type="file" name="photo" accept="image/*" class="hidden" x-ref="photoInput"
+                                   @change="if($event.target.files[0]) { const r = new FileReader(); r.onload = e => preview = e.target.result; r.readAsDataURL($event.target.files[0]); }">
+                        </label>
+                        @error('photo')
+                            <p class="text-xs text-red-600">{{ $message }}</p>
+                        @enderror
+                        <button type="submit"
+                                class="px-4 py-1.5 bg-emerald-600 text-white text-sm rounded-lg hover:bg-emerald-700 transition">
+                            {{ __('Опубликовать') }}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/resources/views/partials/dashboard/posts-feed.blade.php
+++ b/resources/views/partials/dashboard/posts-feed.blade.php
@@ -1,0 +1,40 @@
+@if($recentPosts->isNotEmpty())
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <div class="p-6">
+        <h3 class="text-lg font-semibold text-gray-900 mb-4">{{ __('Посты') }}</h3>
+        <div class="space-y-4">
+            @foreach($recentPosts as $post)
+                <div class="flex items-start space-x-3 p-3 rounded-lg bg-gray-50">
+                    <img src="{{ $post->user->avatar_url }}" alt=""
+                         class="w-9 h-9 rounded-full object-cover flex-shrink-0">
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-center justify-between">
+                            <span class="text-sm font-medium text-gray-900">{{ $post->user->name }}</span>
+                            <div class="flex items-center space-x-2">
+                                <span class="text-xs text-gray-500">{{ $post->created_at->diffForHumans() }}</span>
+                                @if($post->user_id === auth()->id())
+                                    <form action="{{ route('posts.destroy', $post) }}" method="POST"
+                                          onsubmit="return confirm('{{ __('Удалить пост?') }}')">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="text-gray-400 hover:text-red-500" title="{{ __('Удалить') }}">
+                                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                                            </svg>
+                                        </button>
+                                    </form>
+                                @endif
+                            </div>
+                        </div>
+                        <p class="text-sm text-gray-700 mt-1 whitespace-pre-line">{{ $post->body }}</p>
+                        @if($post->getFirstMediaUrl('photos'))
+                            <img src="{{ $post->getFirstMediaUrl('photos') }}" alt=""
+                                 class="mt-2 rounded-lg max-h-64 object-cover">
+                        @endif
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </div>
+</div>
+@endif

--- a/resources/views/partials/dashboard/profile-card.blade.php
+++ b/resources/views/partials/dashboard/profile-card.blade.php
@@ -1,0 +1,16 @@
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <div class="p-4">
+        <div class="flex flex-col items-center text-center">
+            <img src="{{ auth()->user()->avatar_url }}" alt="{{ auth()->user()->name }}"
+                 class="w-16 h-16 rounded-full object-cover mb-3">
+            <h3 class="text-sm font-semibold text-gray-900 truncate w-full">{{ auth()->user()->name }}</h3>
+            @if(auth()->user()->position)
+                <p class="text-xs text-gray-500 mt-0.5">{{ auth()->user()->position }}</p>
+            @endif
+            <a href="{{ route('profile.edit') }}"
+               class="mt-2 text-xs text-emerald-600 hover:text-emerald-800">
+                {{ __('Редактировать профиль') }}
+            </a>
+        </div>
+    </div>
+</div>

--- a/resources/views/partials/dashboard/tenders-widget.blade.php
+++ b/resources/views/partials/dashboard/tenders-widget.blade.php
@@ -1,0 +1,27 @@
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <div class="p-4">
+        <h4 class="text-sm font-semibold text-gray-900 mb-3">{{ __('Мои закупки') }}</h4>
+        @if($myTenders->isNotEmpty())
+            <ul class="space-y-2">
+                @foreach($myTenders as $tender)
+                    <li class="text-sm">
+                        <a href="{{ $tender['url'] }}" class="text-gray-700 hover:text-emerald-600 block truncate">
+                            {{ $tender['title'] ?: $tender['number'] }}
+                        </a>
+                        <div class="flex items-center space-x-2 mt-0.5">
+                            <span class="text-xs px-1.5 py-0.5 rounded {{ $tender['type'] === 'rfq' ? 'bg-yellow-100 text-yellow-800' : 'bg-purple-100 text-purple-800' }}">
+                                {{ $tender['type'] === 'rfq' ? 'ЗЦ' : 'Аукцион' }}
+                            </span>
+                            <span class="text-xs text-gray-500">{{ $tender['status'] }}</span>
+                        </div>
+                    </li>
+                @endforeach
+            </ul>
+        @else
+            <p class="text-xs text-gray-500">{{ __('Нет закупок') }}</p>
+        @endif
+        <a href="{{ route('tenders.my') }}" class="mt-2 inline-block text-xs text-emerald-600 hover:text-emerald-800">
+            {{ __('Все закупки') }} &rarr;
+        </a>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\NewsController;
 use App\Http\Controllers\UserKeywordController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\NotificationController;
+use App\Http\Controllers\PostController;
 use App\Http\Controllers\TempUploadController;
 use App\Http\Controllers\TenderController;
 
@@ -89,6 +90,9 @@ Route::get('companies/{company}', [CompanyController::class, 'show'])->name('com
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
     Route::get('/dashboard/activities', [DashboardController::class, 'loadMoreActivities'])->name('dashboard.activities');
+
+    Route::post('/posts', [PostController::class, 'store'])->name('posts.store');
+    Route::delete('/posts/{post}', [PostController::class, 'destroy'])->name('posts.destroy');
 });
 
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
## Summary
- 3-колоночный dashboard layout (grid 1+3+1): профиль/компании/проекты | новости/посты/активность | закупки/приглашения/заявки
- Новая модель `Post` с CRUD (создание + удаление), медиа-коллекция `photos`, activity log
- 11 партиалов dashboard: profile-card, join-requests, my-companies, my-projects, news-widget, post-form, posts-feed, activity-feed, tenders-widget, invitations-widget, bids-widget
- `User::moderatedCompanies()` — добавлен `slug` в select
- `DashboardController::index()` полностью переписан — собирает данные для всех виджетов

Closes #60

## Test plan
- [x] Все 192 теста проходят (401 assertion)
- [x] Новые тесты: view data, companies в dashboard, post CRUD, валидация, ownership
- [x] Pint — все новые файлы проходят проверку
- [ ] Ручная проверка: dashboard загружается с данными во всех 3 колонках
- [ ] Посты создаются/удаляются, фото прикрепляется
- [ ] Виджеты закупок/приглашений/заявок показывают данные

🤖 Generated with [Claude Code](https://claude.com/claude-code)