### PR TITLE
feat: #68 — cleanup:test-data + защита удаления аукционов

### DIFF
--- a/app/Console/Commands/CleanupTestDataCommand.php
+++ b/app/Console/Commands/CleanupTestDataCommand.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Auction;
+use App\Models\AuctionBid;
+use App\Models\Company;
+use App\Models\Project;
+use App\Models\Rfq;
+use App\Models\RfqBid;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class CleanupTestDataCommand extends Command
+{
+    protected $signature = 'cleanup:test-data {--force : Пропустить подтверждения}';
+
+    protected $description = 'Удаление тестовых компаний и всех связанных данных (soft-delete)';
+
+    public function handle(): int
+    {
+        $companies = Company::withCount(['rfqs', 'projects', 'joinRequests'])
+            ->orderBy('id')
+            ->get();
+
+        if ($companies->isEmpty()) {
+            $this->info('Компании не найдены.');
+
+            return self::SUCCESS;
+        }
+
+        // Company doesn't have auctions() relationship — count separately
+        $auctionCounts = Auction::selectRaw('company_id, count(*) as cnt')
+            ->whereIn('company_id', $companies->pluck('id'))
+            ->groupBy('company_id')
+            ->pluck('cnt', 'company_id');
+
+        $this->table(
+            ['ID', 'Название', 'Slug', 'RFQs', 'Аукционы', 'Проекты', 'Заявки'],
+            $companies->map(fn (Company $c) => [
+                $c->id,
+                $c->name,
+                $c->slug,
+                $c->rfqs_count,
+                $auctionCounts->get($c->id, 0),
+                $c->projects_count,
+                $c->join_requests_count,
+            ])
+        );
+
+        $input = $this->option('force')
+            ? 'all'
+            : $this->ask('Введите ID компаний для удаления (через запятую) или "all" для всех');
+
+        if (! $input) {
+            $this->info('Отменено.');
+
+            return self::SUCCESS;
+        }
+
+        if ($input === 'all') {
+            $selectedCompanies = $companies;
+        } else {
+            $ids = array_map('intval', array_filter(explode(',', $input)));
+            $selectedCompanies = $companies->whereIn('id', $ids);
+
+            if ($selectedCompanies->isEmpty()) {
+                $this->error('Компании с указанными ID не найдены.');
+
+                return self::FAILURE;
+            }
+        }
+
+        $companyIds = $selectedCompanies->pluck('id')->toArray();
+
+        // Подсчёт каскадных записей
+        $rfqIds = Rfq::whereIn('company_id', $companyIds)->pluck('id');
+        $auctionIds = Auction::whereIn('company_id', $companyIds)->pluck('id');
+        $projectIds = Project::whereIn('company_id', $companyIds)->pluck('id');
+
+        $rfqBidsCount = RfqBid::whereIn('rfq_id', $rfqIds)->count();
+        $auctionBidsCount = AuctionBid::whereIn('auction_id', $auctionIds)->count();
+        $rfqInvitationsCount = DB::table('rfq_invitations')->whereIn('rfq_id', $rfqIds)->count();
+        $auctionInvitationsCount = DB::table('auction_invitations')->whereIn('auction_id', $auctionIds)->count();
+        $companyUserCount = DB::table('company_user')->whereIn('company_id', $companyIds)->count();
+        $companyProjectCount = DB::table('company_project')->whereIn('company_id', $companyIds)->count();
+        $joinRequestsCount = DB::table('company_join_requests')->whereIn('company_id', $companyIds)->count();
+
+        $this->newLine();
+        $this->warn('Будет удалено:');
+        $this->table(
+            ['Тип', 'Количество', 'Тип удаления'],
+            [
+                ['Компании', count($companyIds), 'soft-delete'],
+                ['RFQ', $rfqIds->count(), 'soft-delete'],
+                ['Ставки RFQ', $rfqBidsCount, 'soft-delete'],
+                ['Аукционы', $auctionIds->count(), 'soft-delete'],
+                ['Ставки аукционов', $auctionBidsCount, 'soft-delete'],
+                ['Проекты', $projectIds->count(), 'soft-delete'],
+                ['Приглашения RFQ', $rfqInvitationsCount, 'hard-delete'],
+                ['Приглашения аукционов', $auctionInvitationsCount, 'hard-delete'],
+                ['Связи компания-пользователь', $companyUserCount, 'hard-delete'],
+                ['Связи компания-проект', $companyProjectCount, 'hard-delete'],
+                ['Заявки на вступление', $joinRequestsCount, 'hard-delete'],
+            ]
+        );
+
+        if (! $this->option('force') && ! $this->confirm('Подтвердить удаление?')) {
+            $this->info('Отменено.');
+
+            return self::SUCCESS;
+        }
+
+        DB::transaction(function () use ($companyIds, $rfqIds, $auctionIds, $projectIds) {
+            // Soft-delete ставок
+            RfqBid::whereIn('rfq_id', $rfqIds)->delete();
+            AuctionBid::whereIn('auction_id', $auctionIds)->delete();
+
+            // Hard-delete приглашений (нет SoftDeletes)
+            DB::table('rfq_invitations')->whereIn('rfq_id', $rfqIds)->delete();
+            DB::table('auction_invitations')->whereIn('auction_id', $auctionIds)->delete();
+
+            // Soft-delete RFQ и аукционов
+            Rfq::whereIn('company_id', $companyIds)->delete();
+            Auction::whereIn('company_id', $companyIds)->delete();
+
+            // Soft-delete проектов
+            Project::whereIn('company_id', $companyIds)->delete();
+
+            // Hard-delete pivot-записей
+            DB::table('company_user')->whereIn('company_id', $companyIds)->delete();
+            DB::table('company_project')->whereIn('company_id', $companyIds)->delete();
+            DB::table('company_join_requests')->whereIn('company_id', $companyIds)->delete();
+
+            // Soft-delete компаний
+            Company::whereIn('id', $companyIds)->delete();
+        });
+
+        $this->newLine();
+        $this->info('Удаление завершено. Удалено компаний: '.count($companyIds));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Orchid/Screens/AuctionEditScreen.php
+++ b/app/Orchid/Screens/AuctionEditScreen.php
@@ -12,6 +12,7 @@ use Orchid\Screen\Fields\DateTimer;
 use Orchid\Screen\Fields\Upload;
 use Orchid\Screen\Actions\Button;
 use Orchid\Support\Facades\Layout;
+use Orchid\Support\Facades\Alert;
 use Orchid\Support\Facades\Toast;
 use Illuminate\Http\Request;
 
@@ -175,10 +176,16 @@ class AuctionEditScreen extends Screen
      */
     public function remove(Auction $auction)
     {
+        if (! in_array($auction->status, ['draft', 'cancelled'])) {
+            Alert::error('Можно удалить только черновики и отменённые аукционы');
+
+            return back();
+        }
+
         $auction->delete();
-        
+
         Toast::info('Аукцион успешно удалён.');
-        
+
         return redirect()->route('platform.auctions.list');
     }
 }

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -4,6 +4,22 @@
 
 ---
 
+## 2026-02-21 — #68: Удаление тестовых данных
+
+**Задача:** Безопасное удаление тестовых компаний перед запуском + защита удаления аукционов в админке.
+
+**Что сделано:**
+1. Создана artisan-команда `cleanup:test-data` — интерактивное удаление компаний с каскадным soft-delete (RFQ, аукционы, ставки, проекты) и hard-delete pivot-записей (invitations, company_user, company_project, join_requests). Поддержка `--force` для автоматического режима.
+2. Добавлена проверка статуса в `AuctionEditScreen::remove()` — удаление только `draft` и `cancelled` (как в RfqEditScreen).
+3. Написаны тесты для команды очистки (3 теста).
+
+**Изменённые файлы:**
+- `app/Console/Commands/CleanupTestDataCommand.php` — **новый**
+- `app/Orchid/Screens/AuctionEditScreen.php` — добавлена проверка статуса + import Alert
+- `tests/Feature/CleanupTestDataCommandTest.php` — **новый** (3 теста)
+
+---
+
 ## 2026-02-21 — #60: Новая главная страница (dashboard)
 
 **Задача:** Полноценный 3-колоночный dashboard с профилем, новостями, постами, закупками, заявками и приглашениями.

--- a/tests/Feature/CleanupTestDataCommandTest.php
+++ b/tests/Feature/CleanupTestDataCommandTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Auction;
+use App\Models\AuctionBid;
+use App\Models\Company;
+use App\Models\Project;
+use App\Models\Rfq;
+use App\Models\RfqBid;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class CleanupTestDataCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected Company $company;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create(['email_verified_at' => now()]);
+        $this->company = Company::factory()->create([
+            'created_by' => $this->user->id,
+            'is_verified' => true,
+        ]);
+        $this->company->assignModerator($this->user, 'owner');
+    }
+
+    protected function createRfq(array $attributes = []): Rfq
+    {
+        return Rfq::create(array_merge([
+            'number' => Rfq::generateNumber(),
+            'title' => 'Тестовый RFQ',
+            'description' => 'Описание',
+            'company_id' => $this->company->id,
+            'created_by' => $this->user->id,
+            'type' => 'open',
+            'start_date' => now()->subDay(),
+            'end_date' => now()->addDays(7),
+            'status' => 'active',
+        ], $attributes));
+    }
+
+    protected function createAuction(array $attributes = []): Auction
+    {
+        return Auction::create(array_merge([
+            'number' => Auction::generateNumber(),
+            'title' => 'Тестовый аукцион',
+            'description' => 'Описание',
+            'company_id' => $this->company->id,
+            'created_by' => $this->user->id,
+            'type' => 'open',
+            'start_date' => now()->subDay(),
+            'end_date' => now()->addDays(7),
+            'trading_start' => now()->addDays(8),
+            'starting_price' => 1000000,
+            'step_percent' => 2.5,
+            'status' => 'active',
+        ], $attributes));
+    }
+
+    public function test_cleanup_command_deletes_company_and_cascaded_data(): void
+    {
+        $rfq = $this->createRfq();
+        $auction = $this->createAuction();
+
+        $bidder = User::factory()->create(['email_verified_at' => now()]);
+        $bidderCompany = Company::factory()->create(['created_by' => $bidder->id]);
+
+        RfqBid::create([
+            'rfq_id' => $rfq->id,
+            'company_id' => $bidderCompany->id,
+            'user_id' => $bidder->id,
+            'price' => 500000,
+            'deadline' => 30,
+            'status' => 'pending',
+        ]);
+
+        AuctionBid::create([
+            'auction_id' => $auction->id,
+            'company_id' => $bidderCompany->id,
+            'user_id' => $bidder->id,
+            'price' => 900000,
+            'type' => 'initial',
+            'status' => 'pending',
+        ]);
+
+        DB::table('rfq_invitations')->insert([
+            'rfq_id' => $rfq->id,
+            'company_id' => $bidderCompany->id,
+            'invited_by' => $this->user->id,
+            'status' => 'pending',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('auction_invitations')->insert([
+            'auction_id' => $auction->id,
+            'company_id' => $bidderCompany->id,
+            'status' => 'pending',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $project = Project::create([
+            'name' => 'Тестовый проект',
+            'company_id' => $this->company->id,
+            'created_by' => $this->user->id,
+            'status' => 'active',
+        ]);
+
+        // Run command with --force and specific company ID
+        $this->artisan('cleanup:test-data', ['--force' => true])
+            ->assertExitCode(0);
+
+        // Verify soft-deletes
+        $this->assertSoftDeleted('companies', ['id' => $this->company->id]);
+        $this->assertSoftDeleted('rfqs', ['id' => $rfq->id]);
+        $this->assertSoftDeleted('auctions', ['id' => $auction->id]);
+        $this->assertSoftDeleted('rfq_bids', ['rfq_id' => $rfq->id]);
+        $this->assertSoftDeleted('auction_bids', ['auction_id' => $auction->id]);
+        $this->assertSoftDeleted('projects', ['id' => $project->id]);
+
+        // Verify hard-deletes
+        $this->assertDatabaseMissing('rfq_invitations', ['rfq_id' => $rfq->id]);
+        $this->assertDatabaseMissing('auction_invitations', ['auction_id' => $auction->id]);
+        $this->assertDatabaseMissing('company_user', ['company_id' => $this->company->id]);
+
+        // Verify bidder company is also soft-deleted (--force = all)
+        $this->assertSoftDeleted('companies', ['id' => $bidderCompany->id]);
+    }
+
+    public function test_cleanup_command_with_force_skips_confirmation(): void
+    {
+        $this->artisan('cleanup:test-data', ['--force' => true])
+            ->assertExitCode(0);
+
+        $this->assertSoftDeleted('companies', ['id' => $this->company->id]);
+    }
+
+    public function test_cleanup_command_shows_empty_message_when_no_companies(): void
+    {
+        // Delete all companies first
+        Company::query()->forceDelete();
+        DB::table('company_user')->delete();
+
+        $this->artisan('cleanup:test-data', ['--force' => true])
+            ->expectsOutput('Компании не найдены.')
+            ->assertExitCode(0);
+    }
+}


### PR DESCRIPTION
## Summary
- Добавлена artisan-команда `cleanup:test-data` для безопасного удаления тестовых компаний с каскадным soft-delete всех связанных записей (RFQ, аукционы, ставки, проекты) и hard-delete pivot-записей (invitations, company_user, company_project, join_requests)
- Добавлена защита удаления аукционов в админке (`AuctionEditScreen`) — разрешено только для `draft` и `cancelled` (как в RfqEditScreen)
- Написаны 3 теста для команды очистки

## Test plan
- [x] Все 195 тестов проходят
- [ ] `php artisan cleanup:test-data` — выводит список компаний, удаляет выбранные
- [ ] `php artisan cleanup:test-data --force` — удаляет все без подтверждения
- [ ] В админке нельзя удалить активный/торгующийся аукцион

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)