### PR TITLE
feat: #74 — участники проектов (роли, приглашения, запросы)

### DIFF
--- a/app/Events/ProjectJoinRequestCreated.php
+++ b/app/Events/ProjectJoinRequestCreated.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\ProjectJoinRequest;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProjectJoinRequestCreated
+{
+    use Dispatchable, SerializesModels;
+
+    public ProjectJoinRequest $joinRequest;
+
+    public function __construct(ProjectJoinRequest $joinRequest)
+    {
+        $this->joinRequest = $joinRequest;
+    }
+}

--- a/app/Events/ProjectJoinRequestReviewed.php
+++ b/app/Events/ProjectJoinRequestReviewed.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\ProjectJoinRequest;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProjectJoinRequestReviewed
+{
+    use Dispatchable, SerializesModels;
+
+    public ProjectJoinRequest $joinRequest;
+
+    public string $decision;
+
+    public function __construct(ProjectJoinRequest $joinRequest, string $decision)
+    {
+        $this->joinRequest = $joinRequest;
+        $this->decision = $decision;
+    }
+}

--- a/app/Events/ProjectUserInvited.php
+++ b/app/Events/ProjectUserInvited.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class ProjectUserInvited
+{
+    use Dispatchable, SerializesModels;
+
+    public Project $project;
+
+    public User $invitedUser;
+
+    public User $invitedBy;
+
+    public function __construct(Project $project, User $invitedUser, User $invitedBy)
+    {
+        $this->project = $project;
+        $this->invitedUser = $invitedUser;
+        $this->invitedBy = $invitedBy;
+    }
+}

--- a/app/Http/Controllers/ProjectMemberController.php
+++ b/app/Http/Controllers/ProjectMemberController.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Events\ProjectJoinRequestCreated;
+use App\Events\ProjectJoinRequestReviewed;
+use App\Events\ProjectUserInvited;
+use App\Models\Project;
+use App\Models\ProjectJoinRequest;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class ProjectMemberController extends Controller
+{
+    /**
+     * Пригласить пользователя в проект (для admin/moderator проекта)
+     */
+    public function store(Request $request, Project $project)
+    {
+        if (! $project->canManage(auth()->user())) {
+            abort(403, 'У вас нет прав для управления участниками этого проекта');
+        }
+
+        $validated = $request->validate([
+            'user_id' => 'required|exists:users,id',
+            'role' => 'required|in:admin,moderator,member',
+        ]);
+
+        $user = User::findOrFail($validated['user_id']);
+
+        // Проверка: уже участник?
+        if ($project->isMember($user)) {
+            return back()->with('error', 'Этот пользователь уже является участником проекта');
+        }
+
+        // Проверка: пользователь принадлежит к компании-участнику или компании-владельцу
+        $participantCompanyIds = $project->participants()->pluck('companies.id')->toArray();
+        $participantCompanyIds[] = $project->company_id;
+
+        $userCompanyIds = $user->moderatedCompanies()->pluck('companies.id')->toArray();
+        $userParticipatingCompany = collect($userCompanyIds)->intersect($participantCompanyIds)->first();
+
+        if (! $userParticipatingCompany) {
+            return back()->with('error', 'Пользователь не принадлежит к компании-участнику проекта');
+        }
+
+        $project->addMember($user, \App\Models\Company::find($userParticipatingCompany), $validated['role'], auth()->user());
+
+        event(new ProjectUserInvited($project, $user, auth()->user()));
+
+        return back()->with('success', "Пользователь {$user->name} добавлен в проект");
+    }
+
+    /**
+     * Обновить роль участника
+     */
+    public function update(Request $request, Project $project, User $user)
+    {
+        if (! $project->canManage(auth()->user())) {
+            abort(403, 'У вас нет прав для управления участниками этого проекта');
+        }
+
+        $validated = $request->validate([
+            'role' => 'required|in:admin,moderator,member',
+        ]);
+
+        $project->members()->updateExistingPivot($user->id, [
+            'role' => $validated['role'],
+        ]);
+
+        return back()->with('success', "Роль пользователя {$user->name} обновлена");
+    }
+
+    /**
+     * Удалить участника из проекта
+     */
+    public function destroy(Project $project, User $user)
+    {
+        if (! $project->canManage(auth()->user())) {
+            abort(403, 'У вас нет прав для управления участниками этого проекта');
+        }
+
+        // Нельзя удалить создателя проекта
+        if ($project->created_by === $user->id) {
+            return back()->with('error', 'Нельзя удалить создателя проекта из участников');
+        }
+
+        $project->removeMember($user);
+
+        return back()->with('success', "Пользователь {$user->name} удалён из проекта");
+    }
+
+    /**
+     * Подать запрос на присоединение к проекту
+     */
+    public function storeJoinRequest(Request $request, Project $project)
+    {
+        $user = auth()->user();
+
+        // Проверка: уже участник?
+        if ($project->isMember($user)) {
+            return back()->with('error', 'Вы уже являетесь участником этого проекта');
+        }
+
+        // Проверка: есть ли активный запрос?
+        if ($project->hasPendingRequestFrom($user)) {
+            return back()->with('error', 'Вы уже отправили запрос на присоединение к этому проекту');
+        }
+
+        // Проверка: компания пользователя участвует в проекте
+        $participantCompanyIds = $project->participants()->pluck('companies.id')->toArray();
+        $participantCompanyIds[] = $project->company_id;
+
+        $userCompanyIds = $user->moderatedCompanies()->pluck('companies.id')->toArray();
+        $userParticipatingCompany = collect($userCompanyIds)->intersect($participantCompanyIds)->first();
+
+        if (! $userParticipatingCompany) {
+            return back()->with('error', 'Ваша компания не является участником этого проекта');
+        }
+
+        $validated = $request->validate([
+            'desired_role' => 'nullable|string|max:100',
+            'message' => 'nullable|string|max:1000',
+        ]);
+
+        $joinRequest = ProjectJoinRequest::create([
+            'project_id' => $project->id,
+            'user_id' => $user->id,
+            'company_id' => $userParticipatingCompany,
+            'desired_role' => $validated['desired_role'] ?? null,
+            'message' => $validated['message'] ?? null,
+            'status' => 'pending',
+        ]);
+
+        event(new ProjectJoinRequestCreated($joinRequest));
+
+        return back()->with('success', 'Запрос на присоединение отправлен! Ожидайте ответа.');
+    }
+
+    /**
+     * Одобрить запрос на присоединение
+     */
+    public function approveJoinRequest(ProjectJoinRequest $joinRequest)
+    {
+        if (! $joinRequest->canReview(auth()->user())) {
+            abort(403, 'У вас нет прав для рассмотрения этого запроса');
+        }
+
+        DB::beginTransaction();
+
+        try {
+            $role = $joinRequest->desired_role && in_array($joinRequest->desired_role, ['admin', 'moderator', 'member'])
+                ? $joinRequest->desired_role
+                : 'member';
+
+            $joinRequest->project->addMember(
+                $joinRequest->user,
+                $joinRequest->company,
+                $role,
+                auth()->user()
+            );
+
+            $joinRequest->update([
+                'status' => 'approved',
+                'reviewed_by' => auth()->id(),
+                'reviewed_at' => now(),
+            ]);
+
+            DB::commit();
+
+            event(new ProjectJoinRequestReviewed($joinRequest, 'approved'));
+
+            return back()->with('success', "Запрос одобрен. Пользователь {$joinRequest->user->name} добавлен в проект.");
+        } catch (\Exception $e) {
+            DB::rollBack();
+
+            return back()->with('error', 'Ошибка при одобрении: '.$e->getMessage());
+        }
+    }
+
+    /**
+     * Отклонить запрос на присоединение
+     */
+    public function rejectJoinRequest(Request $request, ProjectJoinRequest $joinRequest)
+    {
+        if (! $joinRequest->canReview(auth()->user())) {
+            abort(403, 'У вас нет прав для рассмотрения этого запроса');
+        }
+
+        $validated = $request->validate([
+            'review_comment' => 'nullable|string|max:500',
+        ]);
+
+        $joinRequest->update([
+            'status' => 'rejected',
+            'reviewed_by' => auth()->id(),
+            'reviewed_at' => now(),
+            'review_comment' => $validated['review_comment'] ?? null,
+        ]);
+
+        event(new ProjectJoinRequestReviewed($joinRequest, 'rejected'));
+
+        return back()->with('success', 'Запрос отклонён');
+    }
+
+    /**
+     * Отозвать свой запрос на присоединение
+     */
+    public function destroyJoinRequest(ProjectJoinRequest $joinRequest)
+    {
+        if (! $joinRequest->canCancel(auth()->user())) {
+            abort(403, 'Вы не можете отозвать этот запрос');
+        }
+
+        $joinRequest->delete();
+
+        return back()->with('success', 'Запрос отозван');
+    }
+}

--- a/app/Listeners/SendProjectJoinRequestNotification.php
+++ b/app/Listeners/SendProjectJoinRequestNotification.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\ProjectJoinRequestCreated;
+use App\Notifications\ProjectJoinRequestNotification;
+
+class SendProjectJoinRequestNotification
+{
+    public function handle(ProjectJoinRequestCreated $event): void
+    {
+        $event->joinRequest->load(['user', 'project.company']);
+
+        // Уведомляем модераторов компании-владельца проекта
+        $moderators = $event->joinRequest->project->company->moderators;
+
+        foreach ($moderators as $moderator) {
+            $moderator->notify(new ProjectJoinRequestNotification($event->joinRequest));
+        }
+    }
+}

--- a/app/Listeners/SendProjectJoinRequestReviewedNotification.php
+++ b/app/Listeners/SendProjectJoinRequestReviewedNotification.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\ProjectJoinRequestReviewed;
+use App\Notifications\ProjectJoinRequestReviewedNotification;
+
+class SendProjectJoinRequestReviewedNotification
+{
+    public function handle(ProjectJoinRequestReviewed $event): void
+    {
+        $event->joinRequest->load(['user', 'project']);
+
+        $event->joinRequest->user->notify(
+            new ProjectJoinRequestReviewedNotification($event->joinRequest, $event->decision)
+        );
+    }
+}

--- a/app/Listeners/SendProjectUserInvitedNotification.php
+++ b/app/Listeners/SendProjectUserInvitedNotification.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\ProjectUserInvited;
+use App\Notifications\ProjectUserInvitedNotification;
+
+class SendProjectUserInvitedNotification
+{
+    public function handle(ProjectUserInvited $event): void
+    {
+        $event->invitedUser->notify(
+            new ProjectUserInvitedNotification($event->project, $event->invitedBy)
+        );
+    }
+}

--- a/app/Models/ProjectJoinRequest.php
+++ b/app/Models/ProjectJoinRequest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProjectJoinRequest extends Model
+{
+    protected $fillable = [
+        'project_id',
+        'user_id',
+        'company_id',
+        'desired_role',
+        'message',
+        'status',
+        'reviewed_by',
+        'reviewed_at',
+        'review_comment',
+    ];
+
+    protected $casts = [
+        'reviewed_at' => 'datetime',
+    ];
+
+    public function project(): BelongsTo
+    {
+        return $this->belongsTo(Project::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function reviewer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'reviewed_by');
+    }
+
+    public function scopePending($query)
+    {
+        return $query->where('status', 'pending');
+    }
+
+    public function scopeApproved($query)
+    {
+        return $query->where('status', 'approved');
+    }
+
+    public function scopeRejected($query)
+    {
+        return $query->where('status', 'rejected');
+    }
+
+    public function canCancel(User $user): bool
+    {
+        return $this->user_id === $user->id && $this->status === 'pending';
+    }
+
+    public function canReview(User $user): bool
+    {
+        if (! $this->relationLoaded('project')) {
+            $this->load('project');
+        }
+
+        return $this->project && $this->project->canManage($user) && $this->status === 'pending';
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,10 +2,9 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Laravel\Scout\Searchable;
 use Orchid\Filters\Types\Like;
 use Orchid\Filters\Types\Where;
@@ -50,9 +49,9 @@ class User extends Orchid
      * @var array
      */
     protected $casts = [
-        'permissions'          => 'array',
-        'email_verified_at'    => 'datetime',
-        'password'             => 'hashed',
+        'permissions' => 'array',
+        'email_verified_at' => 'datetime',
+        'password' => 'hashed',
     ];
 
     /**
@@ -61,9 +60,9 @@ class User extends Orchid
      * @var array
      */
     protected $allowedFilters = [
-        'id'         => Where::class,
-        'name'       => Like::class,
-        'email'      => Like::class,
+        'id' => Where::class,
+        'name' => Like::class,
+        'email' => Like::class,
         'updated_at' => WhereDateStartEnd::class,
         'created_at' => WhereDateStartEnd::class,
     ];
@@ -100,8 +99,8 @@ class User extends Orchid
     {
         return $this->belongsToMany(Company::class, 'company_user')
             ->select('companies.id', 'companies.name', 'companies.slug', 'companies.inn', 'companies.is_verified') // ⚠️ ЯВНО указываем поля
-        ->withPivot(['role', 'added_by', 'added_at', 'can_manage_moderators'])
-        ->withTimestamps();
+            ->withPivot(['role', 'added_by', 'added_at', 'can_manage_moderators'])
+            ->withTimestamps();
     }
 
     /**
@@ -118,6 +117,16 @@ class User extends Orchid
     public function comments(): HasMany
     {
         return $this->hasMany(Comment::class);
+    }
+
+    /**
+     * Проекты, где пользователь является участником (через pivot-таблицу)
+     */
+    public function projectMemberships(): BelongsToMany
+    {
+        return $this->belongsToMany(Project::class, 'project_user')
+            ->withPivot(['company_id', 'role', 'added_by', 'added_at'])
+            ->withTimestamps();
     }
 
     /**
@@ -178,12 +187,13 @@ class User extends Orchid
             if (str_starts_with($this->avatar, 'http')) {
                 return $this->avatar;
             }
+
             // Если это локальный файл
-            return asset('storage/' . $this->avatar);
+            return asset('storage/'.$this->avatar);
         }
 
         // Дефолтный аватар (генерация по инициалам)
-        return 'https://ui-avatars.com/api/?name=' . urlencode($this->name) . '&color=7F9CF5&background=EBF4FF';
+        return 'https://ui-avatars.com/api/?name='.urlencode($this->name).'&color=7F9CF5&background=EBF4FF';
     }
 
     // ========================

--- a/app/Notifications/ProjectJoinRequestNotification.php
+++ b/app/Notifications/ProjectJoinRequestNotification.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\ProjectJoinRequest;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ProjectJoinRequestNotification extends Notification
+{
+    use Queueable;
+
+    public ProjectJoinRequest $joinRequest;
+
+    public function __construct(ProjectJoinRequest $joinRequest)
+    {
+        $this->joinRequest = $joinRequest;
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['database', 'mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Запрос на присоединение к проекту: '.$this->joinRequest->project->name)
+            ->greeting('Здравствуйте, '.$notifiable->name.'!')
+            ->line('Пользователь **'.$this->joinRequest->user->name.'** отправил запрос на присоединение к проекту **'.$this->joinRequest->project->name.'**.')
+            ->when($this->joinRequest->message, function ($message) {
+                return $message->line('Сообщение: '.$this->joinRequest->message);
+            })
+            ->action('Рассмотреть запрос', route('projects.show', $this->joinRequest->project->slug))
+            ->line('Перейдите на вкладку «Люди» для одобрения или отклонения запроса.');
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'type' => 'project_join_request',
+            'project_id' => $this->joinRequest->project_id,
+            'project_title' => $this->joinRequest->project->name,
+            'user_id' => $this->joinRequest->user_id,
+            'user_name' => $this->joinRequest->user->name,
+            'url' => route('projects.show', $this->joinRequest->project->slug),
+        ];
+    }
+}

--- a/app/Notifications/ProjectJoinRequestReviewedNotification.php
+++ b/app/Notifications/ProjectJoinRequestReviewedNotification.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\ProjectJoinRequest;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ProjectJoinRequestReviewedNotification extends Notification
+{
+    use Queueable;
+
+    public ProjectJoinRequest $joinRequest;
+
+    public string $decision;
+
+    public function __construct(ProjectJoinRequest $joinRequest, string $decision)
+    {
+        $this->joinRequest = $joinRequest;
+        $this->decision = $decision;
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['database', 'mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        $statusText = $this->decision === 'approved' ? 'одобрен' : 'отклонён';
+
+        $mail = (new MailMessage)
+            ->subject('Ваш запрос на присоединение к проекту '.$statusText)
+            ->greeting('Здравствуйте, '.$notifiable->name.'!')
+            ->line('Ваш запрос на присоединение к проекту **'.$this->joinRequest->project->name.'** был '.$statusText.'.');
+
+        if ($this->joinRequest->review_comment) {
+            $mail->line('Комментарий: '.$this->joinRequest->review_comment);
+        }
+
+        return $mail
+            ->action('Просмотреть проект', route('projects.show', $this->joinRequest->project->slug))
+            ->line('Спасибо за использование Bizzio.ru!');
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'type' => 'project_join_request_reviewed',
+            'project_id' => $this->joinRequest->project_id,
+            'project_title' => $this->joinRequest->project->name,
+            'decision' => $this->decision,
+            'url' => route('projects.show', $this->joinRequest->project->slug),
+        ];
+    }
+}

--- a/app/Notifications/ProjectUserInvitedNotification.php
+++ b/app/Notifications/ProjectUserInvitedNotification.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class ProjectUserInvitedNotification extends Notification
+{
+    use Queueable;
+
+    public Project $project;
+
+    public User $invitedBy;
+
+    public function __construct(Project $project, User $invitedBy)
+    {
+        $this->project = $project;
+        $this->invitedBy = $invitedBy;
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['database', 'mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Вас добавили в проект: '.$this->project->name)
+            ->greeting('Здравствуйте, '.$notifiable->name.'!')
+            ->line('Пользователь **'.$this->invitedBy->name.'** добавил вас в проект **'.$this->project->name.'**.')
+            ->action('Просмотреть проект', route('projects.show', $this->project->slug))
+            ->line('Спасибо за использование Bizzio.ru!');
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'type' => 'project_user_invited',
+            'project_id' => $this->project->id,
+            'project_title' => $this->project->name,
+            'invited_by_name' => $this->invitedBy->name,
+            'url' => route('projects.show', $this->project->slug),
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,14 +4,20 @@ namespace App\Providers;
 
 use App\Events\AuctionTradingStarted;
 use App\Events\CommentCreated;
+use App\Events\CompanyCreated;
 use App\Events\ProjectInvitationSent;
+use App\Events\ProjectJoinRequestCreated;
+use App\Events\ProjectJoinRequestReviewed;
+use App\Events\ProjectUserInvited;
 use App\Events\TenderClosed;
 use App\Events\TenderInvitationSent;
-use App\Events\CompanyCreated;
 use App\Listeners\SendAuctionTradingStartedNotification;
 use App\Listeners\SendCommentNotification;
 use App\Listeners\SendCompanyCreatedNotification;
 use App\Listeners\SendProjectInvitationNotification;
+use App\Listeners\SendProjectJoinRequestNotification;
+use App\Listeners\SendProjectJoinRequestReviewedNotification;
+use App\Listeners\SendProjectUserInvitedNotification;
 use App\Listeners\SendTenderClosedNotification;
 use App\Listeners\SendTenderInvitationNotification;
 // Events
@@ -96,5 +102,8 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(TenderClosed::class, SendTenderClosedNotification::class);
         Event::listen(AuctionTradingStarted::class, SendAuctionTradingStartedNotification::class);
         Event::listen(CompanyCreated::class, SendCompanyCreatedNotification::class);
+        Event::listen(ProjectUserInvited::class, SendProjectUserInvitedNotification::class);
+        Event::listen(ProjectJoinRequestCreated::class, SendProjectJoinRequestNotification::class);
+        Event::listen(ProjectJoinRequestReviewed::class, SendProjectJoinRequestReviewedNotification::class);
     }
 }

--- a/database/migrations/2026_02_23_100000_create_project_user_table.php
+++ b/database/migrations/2026_02_23_100000_create_project_user_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('project_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('company_id')->constrained()->onDelete('cascade');
+            $table->enum('role', ['admin', 'moderator', 'member'])->default('member');
+            $table->foreignId('added_by')->nullable()->constrained('users')->onDelete('set null');
+            $table->timestamp('added_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['project_id', 'user_id']);
+            $table->index(['project_id', 'role']);
+            $table->index('user_id');
+            $table->index('company_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('project_user');
+    }
+};

--- a/database/migrations/2026_02_23_100001_create_project_join_requests_table.php
+++ b/database/migrations/2026_02_23_100001_create_project_join_requests_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('project_join_requests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('company_id')->constrained()->onDelete('cascade');
+            $table->string('desired_role', 100)->nullable();
+            $table->text('message')->nullable();
+            $table->enum('status', ['pending', 'approved', 'rejected'])->default('pending');
+            $table->foreignId('reviewed_by')->nullable()->constrained('users')->onDelete('set null');
+            $table->timestamp('reviewed_at')->nullable();
+            $table->text('review_comment')->nullable();
+            $table->timestamps();
+
+            $table->unique(['project_id', 'user_id', 'status'], 'unique_project_pending_request');
+
+            $table->index(['project_id', 'status']);
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('project_join_requests');
+    }
+};

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -4,6 +4,54 @@
 
 ---
 
+## 2026-02-23 — #74: Пользователи в проектах: роли, приглашения, запросы
+
+**Задача:** Добавить пользовательское участие в проектах — приглашения, запросы на присоединение, роли (admin/moderator/member), вкладка «Люди» на странице проекта.
+
+**Что сделано:**
+1. Создана таблица `project_user` — pivot для пользователей-участников проекта (с ролями, компанией, кто добавил).
+2. Создана таблица `project_join_requests` — запросы на присоединение к проекту (по аналогии с company_join_requests).
+3. Создана модель `ProjectJoinRequest` — с relations, scopes, canCancel/canReview.
+4. Обновлена модель `Project` — members(), joinRequests(), isMember(), hasPendingRequestFrom(), addMember(), removeMember(), getUserRoles().
+5. Обновлена модель `User` — projectMemberships() relation.
+6. Создан `ProjectMemberController` — invite, update role, remove, join request CRUD, approve/reject.
+7. Добавлены 7 маршрутов для участников и запросов.
+8. Созданы 3 события: ProjectUserInvited, ProjectJoinRequestCreated, ProjectJoinRequestReviewed.
+9. Созданы 3 слушателя и 3 уведомления (database + mail).
+10. Зарегистрированы события в AppServiceProvider.
+11. Добавлена вкладка «Люди» на странице проекта с формой приглашения (Alpine.js), списком участников, кнопкой запроса, управлением запросами.
+12. Обновлён notification-text.blade.php — 3 новых @case блока.
+13. Обновлён ProjectController: eager-loading members в show(), автодобавление создателя как admin в store().
+14. Написано 22 теста (все проходят).
+
+**Новые файлы (15):**
+- `database/migrations/2026_02_23_100000_create_project_user_table.php`
+- `database/migrations/2026_02_23_100001_create_project_join_requests_table.php`
+- `app/Models/ProjectJoinRequest.php`
+- `app/Http/Controllers/ProjectMemberController.php`
+- `app/Events/ProjectUserInvited.php`
+- `app/Events/ProjectJoinRequestCreated.php`
+- `app/Events/ProjectJoinRequestReviewed.php`
+- `app/Listeners/SendProjectUserInvitedNotification.php`
+- `app/Listeners/SendProjectJoinRequestNotification.php`
+- `app/Listeners/SendProjectJoinRequestReviewedNotification.php`
+- `app/Notifications/ProjectUserInvitedNotification.php`
+- `app/Notifications/ProjectJoinRequestNotification.php`
+- `app/Notifications/ProjectJoinRequestReviewedNotification.php`
+- `resources/views/projects/partials/members-tab.blade.php`
+- `tests/Feature/ProjectMemberTest.php`
+
+**Изменённые файлы (6):**
+- `app/Models/Project.php`
+- `app/Models/User.php`
+- `app/Http/Controllers/ProjectController.php`
+- `app/Providers/AppServiceProvider.php`
+- `routes/web.php`
+- `resources/views/projects/show.blade.php`
+- `resources/views/partials/notification-text.blade.php`
+
+---
+
 ## 2026-02-21 — #68: Удаление тестовых данных
 
 **Задача:** Безопасное удаление тестовых компаний перед запуском + защита удаления аукционов в админке.

--- a/resources/views/partials/notification-text.blade.php
+++ b/resources/views/partials/notification-text.blade.php
@@ -40,6 +40,23 @@
         от {{ $notification->data['user_name'] ?? '' }}
         @break
 
+    @case('project_user_invited')
+        Вас добавили в проект: <strong>{{ $notification->data['project_title'] ?? '' }}</strong>
+        @if(isset($notification->data['invited_by_name']))
+            ({{ $notification->data['invited_by_name'] }})
+        @endif
+        @break
+
+    @case('project_join_request')
+        Запрос на присоединение к проекту <strong>{{ $notification->data['project_title'] ?? '' }}</strong>
+        от {{ $notification->data['user_name'] ?? '' }}
+        @break
+
+    @case('project_join_request_reviewed')
+        Ваш запрос на присоединение к проекту <strong>{{ $notification->data['project_title'] ?? '' }}</strong>
+        {{ ($notification->data['decision'] ?? '') === 'approved' ? 'одобрен' : 'отклонён' }}
+        @break
+
     @default
         {{ $notification->data['message'] ?? 'Новое уведомление' }}
 @endswitch

--- a/resources/views/projects/partials/members-tab.blade.php
+++ b/resources/views/projects/partials/members-tab.blade.php
@@ -1,0 +1,284 @@
+@php
+    $canManage = auth()->check() && $project->canManage(auth()->user());
+    $isMember = auth()->check() && $project->isMember(auth()->user());
+    $pendingRequests = $project->joinRequests()->with(['user', 'company'])->pending()->get();
+
+    // Проверка: может ли текущий пользователь подать запрос
+    $canRequestJoin = false;
+    $hasPendingRequest = false;
+    if (auth()->check() && !$isMember && !$canManage) {
+        $participantCompanyIds = $project->participants->pluck('id')->toArray();
+        $participantCompanyIds[] = $project->company_id;
+        $userCompanyIds = auth()->user()->moderatedCompanies()->pluck('companies.id')->toArray();
+        $canRequestJoin = count(array_intersect($userCompanyIds, $participantCompanyIds)) > 0;
+        $hasPendingRequest = $project->hasPendingRequestFrom(auth()->user());
+    }
+
+    // Группируем участников по компаниям
+    $membersByCompany = $project->members->groupBy('pivot.company_id');
+@endphp
+
+{{-- Форма приглашения пользователя (для менеджеров) --}}
+@if($canManage)
+    <div class="mb-6 p-4 bg-gray-50 rounded-lg" x-data="projectUserSearch()">
+        <h4 class="text-sm font-semibold text-gray-700 mb-3">Пригласить пользователя</h4>
+        <form method="POST" action="{{ route('projects.members.store', $project->slug) }}">
+            @csrf
+            <input type="hidden" name="user_id" x-model="selectedUserId">
+
+            <div class="flex flex-col sm:flex-row gap-3">
+                {{-- Поиск пользователя --}}
+                <div class="flex-1 relative">
+                    <template x-if="!selectedUserId">
+                        <div>
+                            <input type="text"
+                                   x-model="query"
+                                   @input.debounce.300ms="search()"
+                                   @focus="if(query.length >= 2) showResults = true"
+                                   @click.away="showResults = false"
+                                   placeholder="Поиск пользователя по имени или email..."
+                                   class="w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm">
+
+                            {{-- Результаты поиска --}}
+                            <div x-show="showResults"
+                                 x-cloak
+                                 class="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-48 overflow-y-auto">
+                                <template x-if="loading">
+                                    <div class="p-3 text-center text-gray-500 text-sm">Поиск...</div>
+                                </template>
+                                <template x-if="!loading && results.length === 0 && query.length >= 2">
+                                    <div class="p-3 text-center text-gray-500 text-sm">Пользователи не найдены</div>
+                                </template>
+                                <template x-for="user in results" :key="user.id">
+                                    <button type="button"
+                                            @click="selectUser(user)"
+                                            class="w-full text-left px-3 py-2 hover:bg-gray-50 border-b border-gray-100 last:border-0">
+                                        <div class="text-sm font-medium text-gray-900" x-text="user.title"></div>
+                                        <div class="text-xs text-gray-500" x-text="user.subtitle"></div>
+                                    </button>
+                                </template>
+                            </div>
+                        </div>
+                    </template>
+
+                    {{-- Выбранный пользователь --}}
+                    <template x-if="selectedUserId">
+                        <div class="flex items-center gap-2 p-2 bg-white border border-gray-300 rounded-md">
+                            <span class="text-sm text-gray-900 flex-1" x-text="selectedUserName"></span>
+                            <button type="button" @click="clearSelection()" class="text-gray-400 hover:text-red-500">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                </svg>
+                            </button>
+                        </div>
+                    </template>
+                </div>
+
+                {{-- Выбор роли --}}
+                <div>
+                    <select name="role" class="rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm">
+                        @foreach(\App\Models\Project::getUserRoles() as $value => $label)
+                            <option value="{{ $value }}" {{ $value === 'member' ? 'selected' : '' }}>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </div>
+
+                {{-- Кнопка --}}
+                <div>
+                    <button type="submit"
+                            :disabled="!selectedUserId"
+                            class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition disabled:opacity-50 disabled:cursor-not-allowed">
+                        Пригласить
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+@endif
+
+{{-- Кнопка "Присоединиться к проекту" для подходящих пользователей --}}
+@auth
+    @if($canRequestJoin && !$hasPendingRequest)
+        <div class="mb-6 p-4 bg-emerald-50 rounded-lg">
+            <div class="flex items-center justify-between">
+                <div>
+                    <h4 class="text-sm font-semibold text-emerald-800">Ваша компания участвует в этом проекте</h4>
+                    <p class="text-xs text-emerald-600 mt-1">Вы можете подать запрос на присоединение</p>
+                </div>
+                <button type="button"
+                        onclick="document.getElementById('join-project-modal').classList.remove('hidden')"
+                        class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
+                    Присоединиться
+                </button>
+            </div>
+        </div>
+
+        {{-- Модальное окно запроса --}}
+        <div id="join-project-modal" class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
+            <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+                <h3 class="text-lg font-semibold text-gray-900 mb-4">Запрос на присоединение</h3>
+                <form method="POST" action="{{ route('projects.join-requests.store', $project->slug) }}">
+                    @csrf
+                    <div class="mb-4">
+                        <label class="block text-sm font-medium text-gray-700 mb-1">Сообщение (необязательно)</label>
+                        <textarea name="message" rows="3" maxlength="1000"
+                                  placeholder="Расскажите, почему вы хотите присоединиться..."
+                                  class="w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm"></textarea>
+                    </div>
+                    <div class="flex justify-end gap-2">
+                        <button type="button"
+                                onclick="document.getElementById('join-project-modal').classList.add('hidden')"
+                                class="px-4 py-2 bg-gray-200 text-gray-800 rounded-md text-sm hover:bg-gray-300">
+                            Отмена
+                        </button>
+                        <button type="submit"
+                                class="px-4 py-2 bg-emerald-600 text-white rounded-md text-sm hover:bg-emerald-700">
+                            Отправить запрос
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    @elseif($hasPendingRequest)
+        <div class="mb-6 p-4 bg-yellow-50 rounded-lg">
+            <div class="flex items-center justify-between">
+                <div>
+                    <h4 class="text-sm font-semibold text-yellow-800">Ваш запрос на рассмотрении</h4>
+                    <p class="text-xs text-yellow-600 mt-1">Ожидайте решения модератора проекта</p>
+                </div>
+                @php
+                    $myPendingRequest = $project->joinRequests()->where('user_id', auth()->id())->pending()->first();
+                @endphp
+                @if($myPendingRequest)
+                    <form method="POST" action="{{ route('project-join-requests.destroy', $myPendingRequest) }}">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit"
+                                class="inline-flex items-center px-4 py-2 bg-yellow-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-yellow-700 transition">
+                            Отозвать запрос
+                        </button>
+                    </form>
+                @endif
+            </div>
+        </div>
+    @endif
+@endauth
+
+{{-- Список участников --}}
+@if($project->members->isEmpty())
+    <p class="text-gray-500 text-center py-8">Участники проекта пока не добавлены</p>
+@else
+    <div class="space-y-6">
+        @foreach($membersByCompany as $companyId => $members)
+            @php
+                $memberCompany = \App\Models\Company::find($companyId);
+            @endphp
+            @if($memberCompany)
+                <div>
+                    <h4 class="text-sm font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                        {{ $memberCompany->name }}
+                    </h4>
+                    <div class="space-y-3">
+                        @foreach($members as $member)
+                            <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                                <div class="flex items-center gap-3">
+                                    {{-- Аватар с инициалами --}}
+                                    <div class="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center">
+                                        <span class="text-sm font-semibold text-emerald-700">
+                                            {{ strtoupper(mb_substr($member->name, 0, 1)) }}
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <div class="text-sm font-medium text-gray-900">{{ $member->name }}</div>
+                                        <div class="text-xs text-gray-500">{{ $member->email }}</div>
+                                    </div>
+                                    {{-- Бейдж роли --}}
+                                    @php
+                                        $roleBadgeColors = [
+                                            'admin' => 'bg-red-100 text-red-800',
+                                            'moderator' => 'bg-blue-100 text-blue-800',
+                                            'member' => 'bg-gray-100 text-gray-800',
+                                        ];
+                                    @endphp
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium {{ $roleBadgeColors[$member->pivot->role] ?? 'bg-gray-100 text-gray-800' }}">
+                                        {{ \App\Models\Project::getUserRoles()[$member->pivot->role] ?? $member->pivot->role }}
+                                    </span>
+                                </div>
+
+                                {{-- Управление (для менеджеров) --}}
+                                @if($canManage && $member->id !== $project->created_by)
+                                    <div class="flex items-center gap-2">
+                                        {{-- Изменение роли --}}
+                                        <form method="POST" action="{{ route('projects.members.update', [$project->slug, $member->id]) }}" class="inline">
+                                            @csrf
+                                            @method('PUT')
+                                            <select name="role" onchange="this.form.submit()" class="text-xs rounded border-gray-300 py-1">
+                                                @foreach(\App\Models\Project::getUserRoles() as $value => $label)
+                                                    <option value="{{ $value }}" {{ $member->pivot->role === $value ? 'selected' : '' }}>{{ $label }}</option>
+                                                @endforeach
+                                            </select>
+                                        </form>
+                                        {{-- Удаление --}}
+                                        <form method="POST" action="{{ route('projects.members.destroy', [$project->slug, $member->id]) }}"
+                                              onsubmit="return confirm('Удалить пользователя {{ $member->name }} из проекта?')">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="text-red-400 hover:text-red-600" title="Удалить из проекта">
+                                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+                                                </svg>
+                                            </button>
+                                        </form>
+                                    </div>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+        @endforeach
+    </div>
+@endif
+
+{{-- Ожидающие запросы (для менеджеров) --}}
+@if($canManage && $pendingRequests->isNotEmpty())
+    <div class="mt-8">
+        <h4 class="text-sm font-semibold text-gray-700 mb-3">Запросы на присоединение ({{ $pendingRequests->count() }})</h4>
+        <div class="space-y-3">
+            @foreach($pendingRequests as $request)
+                <div class="flex items-center justify-between p-3 bg-yellow-50 rounded-lg border border-yellow-200">
+                    <div class="flex items-center gap-3">
+                        <div class="w-10 h-10 rounded-full bg-yellow-100 flex items-center justify-center">
+                            <span class="text-sm font-semibold text-yellow-700">
+                                {{ strtoupper(mb_substr($request->user->name, 0, 1)) }}
+                            </span>
+                        </div>
+                        <div>
+                            <div class="text-sm font-medium text-gray-900">{{ $request->user->name }}</div>
+                            <div class="text-xs text-gray-500">{{ $request->user->email }} &middot; {{ $request->company->name }}</div>
+                            @if($request->message)
+                                <div class="text-xs text-gray-600 mt-1 italic">{{ $request->message }}</div>
+                            @endif
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <form method="POST" action="{{ route('project-join-requests.approve', $request) }}">
+                            @csrf
+                            <button type="submit"
+                                    class="inline-flex items-center px-3 py-1 bg-emerald-600 text-white text-xs font-semibold rounded hover:bg-emerald-700">
+                                Принять
+                            </button>
+                        </form>
+                        <form method="POST" action="{{ route('project-join-requests.reject', $request) }}">
+                            @csrf
+                            <button type="submit"
+                                    class="inline-flex items-center px-3 py-1 bg-red-600 text-white text-xs font-semibold rounded hover:bg-red-700">
+                                Отклонить
+                            </button>
+                        </form>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </div>
+@endif

--- a/tests/Feature/ProjectMemberTest.php
+++ b/tests/Feature/ProjectMemberTest.php
@@ -1,0 +1,467 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Events\ProjectJoinRequestCreated;
+use App\Events\ProjectJoinRequestReviewed;
+use App\Events\ProjectUserInvited;
+use App\Models\Company;
+use App\Models\Project;
+use App\Models\ProjectJoinRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ProjectMemberTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected Company $company;
+
+    protected Project $project;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create(['email_verified_at' => now()]);
+        $this->company = Company::factory()->create([
+            'created_by' => $this->user->id,
+            'is_verified' => true,
+        ]);
+        $this->company->assignModerator($this->user, 'owner');
+
+        $this->project = Project::factory()->create([
+            'company_id' => $this->company->id,
+            'created_by' => $this->user->id,
+        ]);
+
+        Storage::fake('public');
+        Queue::fake();
+    }
+
+    // ==========================================
+    // Приглашение пользователей
+    // ==========================================
+
+    public function test_manager_can_invite_user_from_participant_company(): void
+    {
+        Event::fake();
+
+        $participantCompany = Company::factory()->create(['is_verified' => true]);
+        $this->project->addParticipant($participantCompany, 'contractor');
+
+        $invitedUser = User::factory()->create();
+        $participantCompany->assignModerator($invitedUser, 'moderator');
+
+        $response = $this->actingAs($this->user)->post(
+            route('projects.members.store', $this->project->slug),
+            ['user_id' => $invitedUser->id, 'role' => 'member']
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+
+        $this->assertTrue($this->project->fresh()->isMember($invitedUser));
+        Event::assertDispatched(ProjectUserInvited::class);
+    }
+
+    public function test_cannot_invite_user_from_non_participant_company(): void
+    {
+        $nonParticipantCompany = Company::factory()->create(['is_verified' => true]);
+        $outsideUser = User::factory()->create();
+        $nonParticipantCompany->assignModerator($outsideUser, 'moderator');
+
+        $response = $this->actingAs($this->user)->post(
+            route('projects.members.store', $this->project->slug),
+            ['user_id' => $outsideUser->id, 'role' => 'member']
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error');
+        $this->assertFalse($this->project->fresh()->isMember($outsideUser));
+    }
+
+    public function test_cannot_invite_duplicate_member(): void
+    {
+        $participantCompany = Company::factory()->create(['is_verified' => true]);
+        $this->project->addParticipant($participantCompany, 'contractor');
+
+        $invitedUser = User::factory()->create();
+        $participantCompany->assignModerator($invitedUser, 'moderator');
+
+        $this->project->addMember($invitedUser, $participantCompany, 'member', $this->user);
+
+        $response = $this->actingAs($this->user)->post(
+            route('projects.members.store', $this->project->slug),
+            ['user_id' => $invitedUser->id, 'role' => 'member']
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error');
+    }
+
+    public function test_non_manager_cannot_invite(): void
+    {
+        $otherUser = User::factory()->create();
+
+        $response = $this->actingAs($otherUser)->post(
+            route('projects.members.store', $this->project->slug),
+            ['user_id' => $otherUser->id, 'role' => 'member']
+        );
+
+        $response->assertStatus(403);
+    }
+
+    public function test_guest_cannot_invite(): void
+    {
+        $response = $this->post(
+            route('projects.members.store', $this->project->slug),
+            ['user_id' => 1, 'role' => 'member']
+        );
+
+        $response->assertRedirect(route('login'));
+    }
+
+    // ==========================================
+    // Запросы на присоединение
+    // ==========================================
+
+    public function test_eligible_user_can_request_to_join(): void
+    {
+        Event::fake();
+
+        $participantCompany = Company::factory()->create(['is_verified' => true]);
+        $this->project->addParticipant($participantCompany, 'contractor');
+
+        $eligibleUser = User::factory()->create();
+        $participantCompany->assignModerator($eligibleUser, 'moderator');
+
+        $response = $this->actingAs($eligibleUser)->post(
+            route('projects.join-requests.store', $this->project->slug),
+            ['message' => 'Хочу участвовать']
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+
+        $this->assertDatabaseHas('project_join_requests', [
+            'project_id' => $this->project->id,
+            'user_id' => $eligibleUser->id,
+            'status' => 'pending',
+        ]);
+
+        Event::assertDispatched(ProjectJoinRequestCreated::class);
+    }
+
+    public function test_non_participant_company_user_cannot_request_join(): void
+    {
+        $nonParticipantCompany = Company::factory()->create(['is_verified' => true]);
+        $outsideUser = User::factory()->create();
+        $nonParticipantCompany->assignModerator($outsideUser, 'moderator');
+
+        $response = $this->actingAs($outsideUser)->post(
+            route('projects.join-requests.store', $this->project->slug),
+            ['message' => 'Хочу участвовать']
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error');
+    }
+
+    public function test_already_member_cannot_request_join(): void
+    {
+        $this->project->addMember($this->user, $this->company, 'admin', $this->user);
+
+        $response = $this->actingAs($this->user)->post(
+            route('projects.join-requests.store', $this->project->slug),
+            ['message' => 'Попытка']
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error');
+    }
+
+    public function test_duplicate_pending_request_denied(): void
+    {
+        $participantCompany = Company::factory()->create(['is_verified' => true]);
+        $this->project->addParticipant($participantCompany, 'contractor');
+
+        $eligibleUser = User::factory()->create();
+        $participantCompany->assignModerator($eligibleUser, 'moderator');
+
+        ProjectJoinRequest::create([
+            'project_id' => $this->project->id,
+            'user_id' => $eligibleUser->id,
+            'company_id' => $participantCompany->id,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($eligibleUser)->post(
+            route('projects.join-requests.store', $this->project->slug),
+            ['message' => 'Повторный запрос']
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error');
+    }
+
+    public function test_user_can_cancel_own_request(): void
+    {
+        $participantCompany = Company::factory()->create(['is_verified' => true]);
+        $this->project->addParticipant($participantCompany, 'contractor');
+
+        $eligibleUser = User::factory()->create();
+        $participantCompany->assignModerator($eligibleUser, 'moderator');
+
+        $joinRequest = ProjectJoinRequest::create([
+            'project_id' => $this->project->id,
+            'user_id' => $eligibleUser->id,
+            'company_id' => $participantCompany->id,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($eligibleUser)->delete(
+            route('project-join-requests.destroy', $joinRequest)
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+        $this->assertDatabaseMissing('project_join_requests', ['id' => $joinRequest->id]);
+    }
+
+    // ==========================================
+    // Одобрение/отклонение запросов
+    // ==========================================
+
+    public function test_manager_can_approve_join_request(): void
+    {
+        Event::fake();
+
+        $participantCompany = Company::factory()->create(['is_verified' => true]);
+        $this->project->addParticipant($participantCompany, 'contractor');
+
+        $requestingUser = User::factory()->create();
+        $participantCompany->assignModerator($requestingUser, 'moderator');
+
+        $joinRequest = ProjectJoinRequest::create([
+            'project_id' => $this->project->id,
+            'user_id' => $requestingUser->id,
+            'company_id' => $participantCompany->id,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($this->user)->post(
+            route('project-join-requests.approve', $joinRequest)
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+
+        $this->assertTrue($this->project->fresh()->isMember($requestingUser));
+        $this->assertEquals('approved', $joinRequest->fresh()->status);
+
+        Event::assertDispatched(ProjectJoinRequestReviewed::class);
+    }
+
+    public function test_manager_can_reject_join_request(): void
+    {
+        Event::fake();
+
+        $participantCompany = Company::factory()->create(['is_verified' => true]);
+        $requestingUser = User::factory()->create();
+        $participantCompany->assignModerator($requestingUser, 'moderator');
+
+        $joinRequest = ProjectJoinRequest::create([
+            'project_id' => $this->project->id,
+            'user_id' => $requestingUser->id,
+            'company_id' => $participantCompany->id,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($this->user)->post(
+            route('project-join-requests.reject', $joinRequest),
+            ['review_comment' => 'Не подходит']
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+
+        $this->assertFalse($this->project->fresh()->isMember($requestingUser));
+        $this->assertEquals('rejected', $joinRequest->fresh()->status);
+        $this->assertEquals('Не подходит', $joinRequest->fresh()->review_comment);
+
+        Event::assertDispatched(ProjectJoinRequestReviewed::class);
+    }
+
+    public function test_non_manager_cannot_approve_request(): void
+    {
+        $otherUser = User::factory()->create();
+
+        $joinRequest = ProjectJoinRequest::create([
+            'project_id' => $this->project->id,
+            'user_id' => $otherUser->id,
+            'company_id' => $this->company->id,
+            'status' => 'pending',
+        ]);
+
+        $response = $this->actingAs($otherUser)->post(
+            route('project-join-requests.approve', $joinRequest)
+        );
+
+        $response->assertStatus(403);
+    }
+
+    // ==========================================
+    // Управление участниками
+    // ==========================================
+
+    public function test_manager_can_change_member_role(): void
+    {
+        $participantCompany = Company::factory()->create(['is_verified' => true]);
+        $this->project->addParticipant($participantCompany, 'contractor');
+
+        $memberUser = User::factory()->create();
+        $participantCompany->assignModerator($memberUser, 'moderator');
+        $this->project->addMember($memberUser, $participantCompany, 'member', $this->user);
+
+        $response = $this->actingAs($this->user)->put(
+            route('projects.members.update', [$this->project->slug, $memberUser->id]),
+            ['role' => 'moderator']
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+
+        $updatedMember = $this->project->fresh()->members()->where('users.id', $memberUser->id)->first();
+        $this->assertEquals('moderator', $updatedMember->pivot->role);
+    }
+
+    public function test_manager_can_remove_member(): void
+    {
+        $participantCompany = Company::factory()->create(['is_verified' => true]);
+        $this->project->addParticipant($participantCompany, 'contractor');
+
+        $memberUser = User::factory()->create();
+        $participantCompany->assignModerator($memberUser, 'moderator');
+        $this->project->addMember($memberUser, $participantCompany, 'member', $this->user);
+
+        $response = $this->actingAs($this->user)->delete(
+            route('projects.members.destroy', [$this->project->slug, $memberUser->id])
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+        $this->assertFalse($this->project->fresh()->isMember($memberUser));
+    }
+
+    public function test_cannot_remove_project_creator(): void
+    {
+        $this->project->addMember($this->user, $this->company, 'admin', $this->user);
+
+        $response = $this->actingAs($this->user)->delete(
+            route('projects.members.destroy', [$this->project->slug, $this->user->id])
+        );
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error');
+        $this->assertTrue($this->project->fresh()->isMember($this->user));
+    }
+
+    // ==========================================
+    // Вкладка "Люди" на странице проекта
+    // ==========================================
+
+    public function test_project_show_page_has_people_tab(): void
+    {
+        $response = $this->get(route('projects.show', $this->project->slug));
+
+        $response->assertStatus(200);
+        $response->assertSee('Люди');
+    }
+
+    public function test_people_tab_shows_members(): void
+    {
+        $participantCompany = Company::factory()->create(['is_verified' => true]);
+        $this->project->addParticipant($participantCompany, 'contractor');
+
+        $memberUser = User::factory()->create(['name' => 'Тестовый Участник']);
+        $participantCompany->assignModerator($memberUser, 'moderator');
+        $this->project->addMember($memberUser, $participantCompany, 'member', $this->user);
+
+        $response = $this->get(route('projects.show', $this->project->slug));
+
+        $response->assertStatus(200);
+        $response->assertSee('Тестовый Участник');
+    }
+
+    // ==========================================
+    // Автоматическое добавление создателя
+    // ==========================================
+
+    public function test_project_creator_is_auto_added_as_admin_member(): void
+    {
+        $projectData = [
+            'name' => 'Автопроект',
+            'description' => 'Тест автодобавления',
+            'company_id' => $this->company->id,
+            'start_date' => now()->format('Y-m-d'),
+            'status' => 'active',
+        ];
+
+        $this->actingAs($this->user)->post(route('projects.store'), $projectData);
+
+        $project = Project::where('name', 'Автопроект')->first();
+
+        $this->assertNotNull($project);
+        $this->assertTrue($project->isMember($this->user));
+
+        $member = $project->members()->where('users.id', $this->user->id)->first();
+        $this->assertEquals('admin', $member->pivot->role);
+    }
+
+    // ==========================================
+    // Модельные методы
+    // ==========================================
+
+    public function test_user_roles_are_available(): void
+    {
+        $roles = Project::getUserRoles();
+
+        $this->assertArrayHasKey('admin', $roles);
+        $this->assertArrayHasKey('moderator', $roles);
+        $this->assertArrayHasKey('member', $roles);
+    }
+
+    public function test_is_member_returns_correct_result(): void
+    {
+        $memberUser = User::factory()->create();
+        $nonMemberUser = User::factory()->create();
+
+        $this->project->addMember($memberUser, $this->company, 'member');
+
+        $this->assertTrue($this->project->isMember($memberUser));
+        $this->assertFalse($this->project->isMember($nonMemberUser));
+    }
+
+    public function test_has_pending_request_from_returns_correct_result(): void
+    {
+        $requestingUser = User::factory()->create();
+
+        $this->assertFalse($this->project->hasPendingRequestFrom($requestingUser));
+
+        ProjectJoinRequest::create([
+            'project_id' => $this->project->id,
+            'user_id' => $requestingUser->id,
+            'company_id' => $this->company->id,
+            'status' => 'pending',
+        ]);
+
+        $this->assertTrue($this->project->hasPendingRequestFrom($requestingUser));
+    }
+}


### PR DESCRIPTION
## Summary

- Добавлена ролевая система участников проектов (admin/moderator/member) через pivot-таблицу `project_user`
- Реализованы запросы на присоединение к проекту (`project_join_requests`) с модерацией (approve/reject)
- Добавлен `ProjectMemberController` — приглашение, изменение роли, удаление, CRUD запросов
- Реализована event-driven архитектура: 3 события + 3 слушателя + 3 уведомления (database + mail)
- Добавлена вкладка «Люди» на странице проекта с Alpine.js поиском пользователей
- Создатель проекта автоматически добавляется как admin-участник
- Обновлена документация CLAUDE.md (events, model relations)

Closes #74

## Test plan

- [x] 22 новых теста в `ProjectMemberTest` — все проходят
- [x] 217 тестов всего (476 assertions) — все проходят
- [ ] Проверить приглашение пользователя через поиск на странице проекта
- [ ] Проверить отправку и модерацию запроса на присоединение
- [ ] Проверить email-уведомления при приглашении и одобрении/отклонении
- [ ] Проверить что создатель проекта автоматически становится admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)