### PR TITLE
fix: allow re-creating company with same INN after soft-delete

### DIFF
--- a/app/Http/Requests/StoreCompanyRequest.php
+++ b/app/Http/Requests/StoreCompanyRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreCompanyRequest extends FormRequest
 {
@@ -16,7 +17,7 @@ class StoreCompanyRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string', 'max:255'],
-            'inn' => ['required', 'string', 'regex:/^\d{10}(\d{2})?$/', 'unique:companies,inn'],
+            'inn' => ['required', 'string', 'regex:/^\d{10}(\d{2})?$/', Rule::unique('companies', 'inn')->whereNull('deleted_at')],
             'legal_form' => ['nullable', 'string', 'max:255'],
             'logo' => ['nullable', 'image', 'max:2048'], // max 2MB
             'short_description' => ['nullable', 'string', 'max:500'],

--- a/app/Http/Requests/UpdateCompanyOrchidRequest.php
+++ b/app/Http/Requests/UpdateCompanyOrchidRequest.php
@@ -39,7 +39,7 @@ class UpdateCompanyOrchidRequest extends FormRequest
                 'string',
                 'size:10',
                 'regex:/^\d{10}$/',
-                Rule::unique('companies', 'inn')->ignore($companyId),
+                Rule::unique('companies', 'inn')->ignore($companyId)->whereNull('deleted_at'),
             ],
             'company.legal_form'        => ['nullable', 'string', 'max:255'],
             'company.short_description' => ['nullable', 'string', 'max:500'],

--- a/database/migrations/2026_02_25_181527_update_companies_inn_unique_exclude_soft_deletes.php
+++ b/database/migrations/2026_02_25_181527_update_companies_inn_unique_exclude_soft_deletes.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Replace full unique on inn/slug with partial unique (excluding soft-deleted).
+     * PostgreSQL supports WHERE in CREATE UNIQUE INDEX.
+     * SQLite (tests) does not — skip for non-pgsql drivers.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        // INN: partial unique excluding soft-deleted
+        DB::statement('ALTER TABLE companies DROP CONSTRAINT IF EXISTS companies_inn_unique');
+        DB::statement('DROP INDEX IF EXISTS companies_inn_unique');
+        DB::statement('CREATE UNIQUE INDEX companies_inn_unique ON companies (inn) WHERE deleted_at IS NULL');
+
+        // Slug: partial unique excluding soft-deleted
+        DB::statement('ALTER TABLE companies DROP CONSTRAINT IF EXISTS companies_slug_unique');
+        DB::statement('DROP INDEX IF EXISTS companies_slug_unique');
+        DB::statement('CREATE UNIQUE INDEX companies_slug_unique ON companies (slug) WHERE deleted_at IS NULL');
+    }
+
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        DB::statement('DROP INDEX IF EXISTS companies_inn_unique');
+        DB::statement('CREATE UNIQUE INDEX companies_inn_unique ON companies (inn)');
+
+        DB::statement('DROP INDEX IF EXISTS companies_slug_unique');
+        DB::statement('CREATE UNIQUE INDEX companies_slug_unique ON companies (slug)');
+    }
+};


### PR DESCRIPTION
## Summary
- **fix**: После soft-delete компании нельзя было создать новую с тем же ИНН — unique constraint и валидация не учитывали `deleted_at`
- **migration**: Заменён полный unique index на partial (`WHERE deleted_at IS NULL`) для `inn` и `slug`
- **validation**: Добавлен `whereNull('deleted_at')` в правила unique для ИНН в обоих form requests

## Test plan
- [ ] Удалить компанию в админке (soft delete)
- [ ] Создать новую компанию с тем же ИНН — должно работать
- [ ] Попытаться создать компанию с ИНН существующей (не удалённой) — должна быть ошибка

🤖 Generated with [Claude Code](https://claude.com/claude-code)