### PR TITLE
feat: модуль подписок (Друзья) #89

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ php artisan tinker
 - **News** — RSS aggregator with keyword filtering, personalized feed
 - **Search** — Search via model `scopeSearch()` with `ilike`/`like` queries (Scout uses `collection` driver; search is not index-based)
 - **Tenders** — Unified view (`/tenders`) combining RFQs and Auctions with shared filters
+- **Subscriptions** — Polymorphic subscriptions (User/Company). Dashboard feed filters by subscriptions + friends-of-friends (2nd level). Public user profiles (`/users/{id}`)
 
 ### Status Lifecycles
 
@@ -123,6 +124,7 @@ Events registered in `AppServiceProvider@registerEventListeners()`:
 - `ProjectUserInvited` → `SendProjectUserInvitedNotification`
 - `ProjectJoinRequestCreated` → `SendProjectJoinRequestNotification`
 - `ProjectJoinRequestReviewed` → `SendProjectJoinRequestReviewedNotification`
+- `UserSubscribed` → `SendUserSubscribedNotification`
 
 ### Key Packages
 - `orchid/platform` — Admin panel
@@ -230,6 +232,8 @@ Company → Rfqs (owner)
 Rfq → RfqBids (one-to-many)
 Company → Auctions (owner)
 Auction → AuctionBids (one-to-many)
+User → Subscriptions (subscriber, one-to-many)
+User/Company ← Subscriptions (subscribable, polymorphic MorphMany)
 ```
 
 - `User` extends `Orchid\Platform\Models\User` (not Laravel's default `Authenticatable`)

--- a/app/Events/UserSubscribed.php
+++ b/app/Events/UserSubscribed.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Subscription;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class UserSubscribed
+{
+    use Dispatchable, SerializesModels;
+
+    public Subscription $subscription;
+
+    public function __construct(Subscription $subscription)
+    {
+        $this->subscription = $subscription;
+    }
+}

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\User;
+use App\Models\Auction;
 use App\Models\Company;
 use App\Models\Project;
 use App\Models\Rfq;
-use App\Models\Auction;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 
@@ -114,7 +114,7 @@ class SearchController extends Controller
                 'id' => $user->id,
                 'title' => $user->name,
                 'subtitle' => $user->email,
-                'url' => '#',
+                'url' => route('users.show', $user),
             ];
         }
 
@@ -130,32 +130,32 @@ class SearchController extends Controller
 
         switch ($type) {
             case 'users':
-                $results = User::search($query)->take(50)->get()->map(fn($item) => $this->formatUser($item));
+                $results = User::search($query)->take(50)->get()->map(fn ($item) => $this->formatUser($item));
                 break;
 
             case 'companies':
-                $results = Company::search($query)->take(50)->get()->map(fn($item) => $this->formatCompany($item));
+                $results = Company::search($query)->take(50)->get()->map(fn ($item) => $this->formatCompany($item));
                 break;
 
             case 'projects':
-                $results = Project::search($query)->take(50)->get()->map(fn($item) => $this->formatProject($item));
+                $results = Project::search($query)->take(50)->get()->map(fn ($item) => $this->formatProject($item));
                 break;
 
             case 'rfqs':
-                $results = Rfq::search($query)->take(50)->get()->map(fn($item) => $this->formatRfq($item));
+                $results = Rfq::search($query)->take(50)->get()->map(fn ($item) => $this->formatRfq($item));
                 break;
 
             case 'auctions':
-                $results = Auction::search($query)->take(50)->get()->map(fn($item) => $this->formatAuction($item));
+                $results = Auction::search($query)->take(50)->get()->map(fn ($item) => $this->formatAuction($item));
                 break;
 
             default: // 'all'
                 $results = collect()
-                    ->merge(User::search($query)->take(10)->get()->map(fn($item) => $this->formatUser($item)))
-                    ->merge(Company::search($query)->take(10)->get()->map(fn($item) => $this->formatCompany($item)))
-                    ->merge(Project::search($query)->take(10)->get()->map(fn($item) => $this->formatProject($item)))
-                    ->merge(Rfq::search($query)->take(10)->get()->map(fn($item) => $this->formatRfq($item)))
-                    ->merge(Auction::search($query)->take(10)->get()->map(fn($item) => $this->formatAuction($item)));
+                    ->merge(User::search($query)->take(10)->get()->map(fn ($item) => $this->formatUser($item)))
+                    ->merge(Company::search($query)->take(10)->get()->map(fn ($item) => $this->formatCompany($item)))
+                    ->merge(Project::search($query)->take(10)->get()->map(fn ($item) => $this->formatProject($item)))
+                    ->merge(Rfq::search($query)->take(10)->get()->map(fn ($item) => $this->formatRfq($item)))
+                    ->merge(Auction::search($query)->take(10)->get()->map(fn ($item) => $this->formatAuction($item)));
                 break;
         }
 
@@ -207,7 +207,7 @@ class SearchController extends Controller
             'title' => $user->name,
             'subtitle' => $user->position,
             'description' => $user->bio,
-            'url' => route('profile.edit'), // TODO: Публичный профиль пользователя
+            'url' => route('users.show', $user),
             'avatar' => $user->avatar,
         ];
     }

--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Events\UserSubscribed;
+use App\Models\Company;
+use App\Models\Subscription;
+use App\Models\User;
+
+class SubscriptionController extends Controller
+{
+    public function index()
+    {
+        $user = auth()->user();
+
+        $userSubscriptions = $user->subscriptions()
+            ->where('subscribable_type', User::class)
+            ->with('subscribable')
+            ->latest()
+            ->get();
+
+        $companySubscriptions = $user->subscriptions()
+            ->where('subscribable_type', Company::class)
+            ->with('subscribable')
+            ->latest()
+            ->get();
+
+        return view('subscriptions.index', compact('userSubscriptions', 'companySubscriptions'));
+    }
+
+    public function subscribeUser(User $user)
+    {
+        $subscriber = auth()->user();
+
+        if ($subscriber->id === $user->id) {
+            return back()->with('error', 'Нельзя подписаться на себя.');
+        }
+
+        $subscription = Subscription::firstOrCreate([
+            'subscriber_id' => $subscriber->id,
+            'subscribable_type' => User::class,
+            'subscribable_id' => $user->id,
+        ]);
+
+        if ($subscription->wasRecentlyCreated) {
+            UserSubscribed::dispatch($subscription);
+        }
+
+        return back()->with('success', "Вы подписались на {$user->name}.");
+    }
+
+    public function unsubscribeUser(User $user)
+    {
+        auth()->user()->subscriptions()
+            ->where('subscribable_type', User::class)
+            ->where('subscribable_id', $user->id)
+            ->delete();
+
+        return back()->with('success', "Вы отписались от {$user->name}.");
+    }
+
+    public function subscribeCompany(Company $company)
+    {
+        $subscriber = auth()->user();
+
+        $subscription = Subscription::firstOrCreate([
+            'subscriber_id' => $subscriber->id,
+            'subscribable_type' => Company::class,
+            'subscribable_id' => $company->id,
+        ]);
+
+        if ($subscription->wasRecentlyCreated) {
+            UserSubscribed::dispatch($subscription);
+        }
+
+        return back()->with('success', "Вы подписались на {$company->name}.");
+    }
+
+    public function unsubscribeCompany(Company $company)
+    {
+        auth()->user()->subscriptions()
+            ->where('subscribable_type', Company::class)
+            ->where('subscribable_id', $company->id)
+            ->delete();
+
+        return back()->with('success', "Вы отписались от {$company->name}.");
+    }
+}

--- a/app/Http/Controllers/UserProfileController.php
+++ b/app/Http/Controllers/UserProfileController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+use App\Models\User;
+
+class UserProfileController extends Controller
+{
+    public function show(User $user)
+    {
+        $companies = $user->moderatedCompanies()->get();
+
+        $recentPosts = Post::with(['user', 'media'])
+            ->where('user_id', $user->id)
+            ->latest()
+            ->take(10)
+            ->get();
+
+        $subscribersCount = $user->subscribers()->count();
+
+        return view('users.show', compact('user', 'companies', 'recentPosts', 'subscribersCount'));
+    }
+}

--- a/app/Listeners/SendUserSubscribedNotification.php
+++ b/app/Listeners/SendUserSubscribedNotification.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\UserSubscribed;
+use App\Models\User;
+use App\Notifications\UserSubscribedNotification;
+
+class SendUserSubscribedNotification
+{
+    public function handle(UserSubscribed $event): void
+    {
+        $subscription = $event->subscription;
+        $target = $subscription->subscribable;
+
+        // Уведомляем только пользователей (не компании)
+        if (! $target instanceof User) {
+            return;
+        }
+
+        // Не уведомлять самого себя
+        if ($target->id === $subscription->subscriber_id) {
+            return;
+        }
+
+        $target->notify(new UserSubscribedNotification($subscription));
+    }
+}

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+class Subscription extends Model
+{
+    protected $fillable = [
+        'subscriber_id',
+        'subscribable_type',
+        'subscribable_id',
+    ];
+
+    public function subscriber(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'subscriber_id');
+    }
+
+    public function subscribable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Notifications/UserSubscribedNotification.php
+++ b/app/Notifications/UserSubscribedNotification.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Subscription;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class UserSubscribedNotification extends Notification
+{
+    use Queueable;
+
+    public Subscription $subscription;
+
+    public function __construct(Subscription $subscription)
+    {
+        $this->subscription = $subscription;
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        $subscriber = $this->subscription->subscriber;
+
+        return [
+            'type' => 'user_subscribed',
+            'subscriber_id' => $subscriber->id,
+            'subscriber_name' => $subscriber->name,
+            'url' => route('users.show', $subscriber),
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,6 +11,7 @@ use App\Events\ProjectJoinRequestReviewed;
 use App\Events\ProjectUserInvited;
 use App\Events\TenderClosed;
 use App\Events\TenderInvitationSent;
+use App\Events\UserSubscribed;
 use App\Listeners\SendAuctionTradingStartedNotification;
 use App\Listeners\SendCommentNotification;
 use App\Listeners\SendCompanyCreatedNotification;
@@ -20,13 +21,14 @@ use App\Listeners\SendProjectJoinRequestReviewedNotification;
 use App\Listeners\SendProjectUserInvitedNotification;
 use App\Listeners\SendTenderClosedNotification;
 use App\Listeners\SendTenderInvitationNotification;
+use App\Listeners\SendUserSubscribedNotification;
 // Events
 use App\Models\Auction;
+use App\Models\Company;
 use App\Models\Rfq;
 use App\Policies\AuctionPolicy;
-use App\Policies\RfqPolicy;
 // Listeners
-use App\Models\Company;
+use App\Policies\RfqPolicy;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
@@ -108,6 +110,7 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(ProjectUserInvited::class, SendProjectUserInvitedNotification::class);
         Event::listen(ProjectJoinRequestCreated::class, SendProjectJoinRequestNotification::class);
         Event::listen(ProjectJoinRequestReviewed::class, SendProjectJoinRequestReviewedNotification::class);
+        Event::listen(UserSubscribed::class, SendUserSubscribedNotification::class);
     }
 
     /**

--- a/database/migrations/2026_02_27_100000_create_subscriptions_table.php
+++ b/database/migrations/2026_02_27_100000_create_subscriptions_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('subscriptions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('subscriber_id')->constrained('users')->cascadeOnDelete();
+            $table->morphs('subscribable');
+            $table->timestamps();
+
+            $table->unique(['subscriber_id', 'subscribable_type', 'subscribable_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('subscriptions');
+    }
+};

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -4,6 +4,63 @@
 
 ---
 
+## 2026-02-27 — Модуль подписок (Друзья) — Issue #89
+
+**Issue:** #89
+
+**Что сделано:**
+- Создана полиморфная таблица `subscriptions` (subscriber_id, subscribable_type, subscribable_id) — подписка на User и Company одной записью
+- Создана модель `Subscription` с `subscriber()` и `subscribable()` связями
+- Расширена модель `User`: `subscriptions()`, `subscribers()`, `isSubscribedTo()` методы
+- Расширена модель `Company`: `subscribers()` связь
+- Создан `SubscriptionController` — подписка/отписка на пользователей и компании, страница «Мои подписки»
+- Создан `UserProfileController` — публичная страница профиля пользователя (`/users/{id}`)
+- Создан Blade-компонент `subscribe-button` — кнопка подписки/отписки с POST/DELETE формами
+- Создано событие `UserSubscribed` + `SendUserSubscribedNotification` listener + `UserSubscribedNotification` (database only)
+- Фильтрация ленты на dashboard: посты от подписок + друзья друзей (2-й уровень), активности от прямых подписок
+- Пустая лента показывает рекомендации верифицированных компаний
+- Кнопка «Подписаться» добавлена на страницу компании (для не-модераторов)
+- URL пользователей в поиске исправлен: `#` → `route('users.show', $user)`
+- Добавлен case `user_subscribed` в уведомления (иконка + текст)
+- 15 тестов (подписка/отписка, self-subscribe guard, идемпотентность, фильтрация ленты, FoF, рекомендации, профиль)
+
+**Новые файлы:**
+- `database/migrations/2026_02_27_100000_create_subscriptions_table.php`
+- `app/Models/Subscription.php`
+- `app/Http/Controllers/SubscriptionController.php`
+- `app/Http/Controllers/UserProfileController.php`
+- `app/Events/UserSubscribed.php`
+- `app/Listeners/SendUserSubscribedNotification.php`
+- `app/Notifications/UserSubscribedNotification.php`
+- `resources/views/users/show.blade.php`
+- `resources/views/subscriptions/index.blade.php`
+- `resources/views/components/subscribe-button.blade.php`
+- `tests/Feature/SubscriptionTest.php`
+
+**Изменённые файлы:**
+- `app/Models/User.php` — добавлены subscriptions(), subscribers(), isSubscribedTo()
+- `app/Models/Company.php` — добавлена subscribers() связь
+- `app/Http/Controllers/DashboardController.php` — фильтрация ленты по подпискам + рекомендации
+- `app/Http/Controllers/SearchController.php` — URL пользователей в поиске
+- `app/Providers/AppServiceProvider.php` — регистрация UserSubscribed event
+- `routes/web.php` — маршруты подписок и профиля пользователя
+- `resources/views/companies/show.blade.php` — кнопка подписки
+- `resources/views/partials/dashboard/posts-feed.blade.php` — ссылки на профили, рекомендации
+- `resources/views/partials/notification-text.blade.php` — case user_subscribed
+- `resources/views/notifications/index.blade.php` — иконка user_subscribed
+
+---
+
+## 2026-02-26 — Обновление CLAUDE.md (PR #100)
+
+**Что сделано:**
+- Добавлен отсутствовавший OAuth-провайдер VK (`socialiteproviders/vkontakte`) в секцию OAuth Providers
+- Исправлено описание Company route model binding: принимает и числовые ID (для Orchid admin) и slug (для публичных маршрутов)
+
+**Изменённые файлы:** `CLAUDE.md`
+
+---
+
 ## 2026-02-26 — Пакет багфиксов: #87, #88, #90, #91, #92, #93, #94
 
 **Issues:** #87, #88, #90, #91, #92, #93, #94

--- a/resources/views/companies/show.blade.php
+++ b/resources/views/companies/show.blade.php
@@ -84,6 +84,10 @@
                     <!-- Кнопки действий -->
                     <div class="flex space-x-2 ml-4">
                         @auth
+                            @unless($company->isModerator(auth()->user()))
+                                @include('components.subscribe-button', ['target' => $company])
+                            @endunless
+
                             @if($company->canManageModerators(auth()->user()))
                                 <!-- Кнопка редактирования (для модераторов) -->
                                 <a href="{{ route('companies.edit', $company) }}" 

--- a/resources/views/components/subscribe-button.blade.php
+++ b/resources/views/components/subscribe-button.blade.php
@@ -1,0 +1,42 @@
+@auth
+    @php
+        $isSubscribed = auth()->user()->isSubscribedTo($target);
+        if ($target instanceof \App\Models\User) {
+            $storeRoute = route('subscriptions.users.store', $target);
+            $destroyRoute = route('subscriptions.users.destroy', $target);
+            $isSelf = auth()->id() === $target->id;
+        } else {
+            $storeRoute = route('subscriptions.companies.store', $target);
+            $destroyRoute = route('subscriptions.companies.destroy', $target);
+            $isSelf = false;
+        }
+    @endphp
+
+    @unless($isSelf)
+        @if($isSubscribed)
+            <form action="{{ $destroyRoute }}" method="POST" class="inline">
+                @csrf
+                @method('DELETE')
+                <button type="submit"
+                    class="inline-flex items-center px-4 py-2 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-red-100 hover:text-red-700 transition group">
+                    <svg class="w-4 h-4 mr-2 text-gray-500 group-hover:text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7a4 4 0 11-8 0 4 4 0 018 0zM9 14a6 6 0 00-6 6v1h12v-1a6 6 0 00-6-6zM21 12h-6"></path>
+                    </svg>
+                    <span class="group-hover:hidden">Подписка</span>
+                    <span class="hidden group-hover:inline">Отписаться</span>
+                </button>
+            </form>
+        @else
+            <form action="{{ $storeRoute }}" method="POST" class="inline">
+                @csrf
+                <button type="submit"
+                    class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition">
+                    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"></path>
+                    </svg>
+                    Подписаться
+                </button>
+            </form>
+        @endif
+    @endunless
+@endauth

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -78,6 +78,13 @@
                                                     </svg>
                                                 </div>
                                                 @break
+                                            @case('user_subscribed')
+                                                <div class="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center">
+                                                    <svg class="h-5 w-5 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"></path>
+                                                    </svg>
+                                                </div>
+                                                @break
                                             @default
                                                 <div class="w-10 h-10 rounded-full bg-gray-100 flex items-center justify-center">
                                                     <svg class="h-5 w-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/resources/views/partials/dashboard/posts-feed.blade.php
+++ b/resources/views/partials/dashboard/posts-feed.blade.php
@@ -1,15 +1,24 @@
 @if($recentPosts->isNotEmpty())
 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
     <div class="p-6">
-        <h3 class="text-lg font-semibold text-gray-900 mb-4">{{ __('Посты') }}</h3>
+        <div class="flex items-center justify-between mb-4">
+            <h3 class="text-lg font-semibold text-gray-900">{{ __('Посты') }}</h3>
+            <a href="{{ route('subscriptions.index') }}" class="text-sm text-emerald-600 hover:text-emerald-800">
+                {{ __('Мои подписки') }}
+            </a>
+        </div>
         <div class="space-y-4">
             @foreach($recentPosts as $post)
                 <div class="flex items-start space-x-3 p-3 rounded-lg bg-gray-50">
-                    <img src="{{ $post->user->avatar_url }}" alt=""
-                         class="w-9 h-9 rounded-full object-cover flex-shrink-0">
+                    <a href="{{ route('users.show', $post->user) }}">
+                        <img src="{{ $post->user->avatar_url }}" alt=""
+                             class="w-9 h-9 rounded-full object-cover flex-shrink-0">
+                    </a>
                     <div class="flex-1 min-w-0">
                         <div class="flex items-center justify-between">
-                            <span class="text-sm font-medium text-gray-900">{{ $post->user->name }}</span>
+                            <a href="{{ route('users.show', $post->user) }}" class="text-sm font-medium text-gray-900 hover:text-emerald-600">
+                                {{ $post->user->name }}
+                            </a>
                             <div class="flex items-center space-x-2">
                                 <span class="text-xs text-gray-500">{{ $post->created_at->diffForHumans() }}</span>
                                 @if($post->user_id === auth()->id())
@@ -35,6 +44,47 @@
                 </div>
             @endforeach
         </div>
+    </div>
+</div>
+@else
+<div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+    <div class="p-6">
+        <div class="text-center py-6">
+            <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
+            </svg>
+            <h3 class="mt-2 text-sm font-medium text-gray-900">{{ __('Подпишитесь на коллег и компании') }}</h3>
+            <p class="mt-1 text-sm text-gray-500">{{ __('Чтобы видеть посты в ленте, подпишитесь на интересных вам пользователей и компании.') }}</p>
+        </div>
+
+        @if(isset($recommendedCompanies) && $recommendedCompanies->isNotEmpty())
+            <div class="mt-4 border-t border-gray-200 pt-4">
+                <h4 class="text-sm font-semibold text-gray-700 mb-3">{{ __('Рекомендуемые компании') }}</h4>
+                <div class="space-y-3">
+                    @foreach($recommendedCompanies as $company)
+                        <div class="flex items-center justify-between p-3 rounded-lg bg-gray-50">
+                            <a href="{{ route('companies.show', $company) }}" class="flex items-center space-x-3 flex-1 min-w-0">
+                                @if($company->logo)
+                                    <img src="{{ Storage::url($company->logo) }}" alt="{{ $company->name }}"
+                                         class="w-10 h-10 rounded-lg object-cover flex-shrink-0">
+                                @else
+                                    <div class="w-10 h-10 bg-gradient-to-br from-emerald-500 to-purple-600 rounded-lg flex items-center justify-center flex-shrink-0">
+                                        <span class="text-sm font-bold text-white">{{ mb_substr($company->name, 0, 1) }}</span>
+                                    </div>
+                                @endif
+                                <div class="min-w-0">
+                                    <p class="text-sm font-medium text-gray-900 truncate">{{ $company->name }}</p>
+                                    @if($company->short_description)
+                                        <p class="text-xs text-gray-500 truncate">{{ $company->short_description }}</p>
+                                    @endif
+                                </div>
+                            </a>
+                            @include('components.subscribe-button', ['target' => $company])
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @endif
     </div>
 </div>
 @endif

--- a/resources/views/partials/notification-text.blade.php
+++ b/resources/views/partials/notification-text.blade.php
@@ -57,6 +57,10 @@
         {{ ($notification->data['decision'] ?? '') === 'approved' ? 'одобрен' : 'отклонён' }}
         @break
 
+    @case('user_subscribed')
+        <strong>{{ $notification->data['subscriber_name'] ?? '' }}</strong> подписался на вас
+        @break
+
     @default
         {{ $notification->data['message'] ?? 'Новое уведомление' }}
 @endswitch

--- a/resources/views/subscriptions/index.blade.php
+++ b/resources/views/subscriptions/index.blade.php
@@ -1,0 +1,106 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Мои подписки') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <!-- Подписки на пользователей -->
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">
+                        {{ __('Пользователи') }}
+                        <span class="text-sm font-normal text-gray-500">({{ $userSubscriptions->count() }})</span>
+                    </h3>
+
+                    @if($userSubscriptions->isNotEmpty())
+                        <div class="space-y-3">
+                            @foreach($userSubscriptions as $subscription)
+                                @if($subscription->subscribable)
+                                    <div class="flex items-center justify-between p-3 rounded-lg bg-gray-50">
+                                        <a href="{{ route('users.show', $subscription->subscribable) }}" class="flex items-center space-x-3 flex-1 min-w-0">
+                                            <img src="{{ $subscription->subscribable->avatar_url }}" alt=""
+                                                 class="w-10 h-10 rounded-full object-cover flex-shrink-0">
+                                            <div class="min-w-0">
+                                                <p class="text-sm font-medium text-gray-900 truncate">{{ $subscription->subscribable->name }}</p>
+                                                @if($subscription->subscribable->position)
+                                                    <p class="text-xs text-gray-500 truncate">{{ $subscription->subscribable->position }}</p>
+                                                @endif
+                                            </div>
+                                        </a>
+                                        <form action="{{ route('subscriptions.users.destroy', $subscription->subscribable) }}" method="POST">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit"
+                                                class="inline-flex items-center px-3 py-1.5 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-red-100 hover:text-red-700 transition">
+                                                {{ __('Отписаться') }}
+                                            </button>
+                                        </form>
+                                    </div>
+                                @endif
+                            @endforeach
+                        </div>
+                    @else
+                        <p class="text-sm text-gray-500 text-center py-4">{{ __('Вы пока не подписаны на пользователей.') }}</p>
+                    @endif
+                </div>
+            </div>
+
+            <!-- Подписки на компании -->
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">
+                        {{ __('Компании') }}
+                        <span class="text-sm font-normal text-gray-500">({{ $companySubscriptions->count() }})</span>
+                    </h3>
+
+                    @if($companySubscriptions->isNotEmpty())
+                        <div class="space-y-3">
+                            @foreach($companySubscriptions as $subscription)
+                                @if($subscription->subscribable)
+                                    <div class="flex items-center justify-between p-3 rounded-lg bg-gray-50">
+                                        <a href="{{ route('companies.show', $subscription->subscribable) }}" class="flex items-center space-x-3 flex-1 min-w-0">
+                                            @if($subscription->subscribable->logo)
+                                                <img src="{{ Storage::url($subscription->subscribable->logo) }}" alt="{{ $subscription->subscribable->name }}"
+                                                     class="w-10 h-10 rounded-lg object-cover flex-shrink-0">
+                                            @else
+                                                <div class="w-10 h-10 bg-gradient-to-br from-emerald-500 to-purple-600 rounded-lg flex items-center justify-center flex-shrink-0">
+                                                    <span class="text-sm font-bold text-white">{{ mb_substr($subscription->subscribable->name, 0, 1) }}</span>
+                                                </div>
+                                            @endif
+                                            <div class="min-w-0">
+                                                <div class="flex items-center space-x-2">
+                                                    <p class="text-sm font-medium text-gray-900 truncate">{{ $subscription->subscribable->name }}</p>
+                                                    @if($subscription->subscribable->is_verified)
+                                                        <svg class="w-4 h-4 text-green-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                                                            <path fill-rule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                                                        </svg>
+                                                    @endif
+                                                </div>
+                                                @if($subscription->subscribable->short_description)
+                                                    <p class="text-xs text-gray-500 truncate">{{ $subscription->subscribable->short_description }}</p>
+                                                @endif
+                                            </div>
+                                        </a>
+                                        <form action="{{ route('subscriptions.companies.destroy', $subscription->subscribable) }}" method="POST">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit"
+                                                class="inline-flex items-center px-3 py-1.5 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-red-100 hover:text-red-700 transition">
+                                                {{ __('Отписаться') }}
+                                            </button>
+                                        </form>
+                                    </div>
+                                @endif
+                            @endforeach
+                        </div>
+                    @else
+                        <p class="text-sm text-gray-500 text-center py-4">{{ __('Вы пока не подписаны на компании.') }}</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -1,0 +1,100 @@
+@extends('layouts.app')
+
+@section('title', $user->name)
+
+@section('content')
+<div class="py-12">
+    <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+        <!-- Профиль -->
+        <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg mb-6">
+            <div class="p-6">
+                <div class="flex items-start space-x-6">
+                    <img src="{{ $user->avatar_url }}" alt="{{ $user->name }}"
+                         class="w-24 h-24 rounded-full object-cover shadow-md">
+
+                    <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <h1 class="text-2xl font-bold text-gray-900">{{ $user->name }}</h1>
+                                @if($user->position)
+                                    <p class="text-gray-600 mt-1">{{ $user->position }}</p>
+                                @endif
+                            </div>
+                            <div class="flex items-center space-x-3">
+                                <span class="text-sm text-gray-500">
+                                    {{ $subscribersCount }} {{ trans_choice('подписчик|подписчика|подписчиков', $subscribersCount) }}
+                                </span>
+                                @include('components.subscribe-button', ['target' => $user])
+                            </div>
+                        </div>
+
+                        @if($user->bio)
+                            <p class="text-gray-700 mt-3">{{ $user->bio }}</p>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Компании пользователя -->
+        @if($companies->isNotEmpty())
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg mb-6">
+                <div class="p-6">
+                    <h2 class="text-lg font-semibold text-gray-900 mb-4">Компании</h2>
+                    <div class="space-y-3">
+                        @foreach($companies as $company)
+                            <a href="{{ route('companies.show', $company) }}"
+                               class="flex items-center space-x-3 p-3 rounded-lg hover:bg-gray-50 transition">
+                                @if($company->logo)
+                                    <img src="{{ Storage::url($company->logo) }}" alt="{{ $company->name }}"
+                                         class="w-10 h-10 rounded-lg object-cover">
+                                @else
+                                    <div class="w-10 h-10 bg-gradient-to-br from-emerald-500 to-purple-600 rounded-lg flex items-center justify-center">
+                                        <span class="text-sm font-bold text-white">{{ mb_substr($company->name, 0, 1) }}</span>
+                                    </div>
+                                @endif
+                                <div>
+                                    <div class="flex items-center space-x-2">
+                                        <span class="text-sm font-medium text-gray-900">{{ $company->name }}</span>
+                                        @if($company->is_verified)
+                                            <svg class="w-4 h-4 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+                                                <path fill-rule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+                                            </svg>
+                                        @endif
+                                    </div>
+                                    @if($company->pivot && $company->pivot->role)
+                                        <span class="text-xs text-gray-500">{{ $company->pivot->role }}</span>
+                                    @endif
+                                </div>
+                            </a>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+        @endif
+
+        <!-- Последние посты -->
+        @if($recentPosts->isNotEmpty())
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6">
+                    <h2 class="text-lg font-semibold text-gray-900 mb-4">Посты</h2>
+                    <div class="space-y-4">
+                        @foreach($recentPosts as $post)
+                            <div class="p-3 rounded-lg bg-gray-50">
+                                <div class="flex items-center justify-between mb-2">
+                                    <span class="text-xs text-gray-500">{{ $post->created_at->diffForHumans() }}</span>
+                                </div>
+                                <p class="text-sm text-gray-700 whitespace-pre-line">{{ $post->body }}</p>
+                                @if($post->getFirstMediaUrl('photos'))
+                                    <img src="{{ $post->getFirstMediaUrl('photos') }}" alt=""
+                                         class="mt-2 rounded-lg max-h-64 object-cover">
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+        @endif
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,9 +13,12 @@ use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\ProjectController;
 use App\Http\Controllers\ProjectMemberController;
 use App\Http\Controllers\RfqController;
+use App\Http\Controllers\SearchController;
+use App\Http\Controllers\SubscriptionController;
 use App\Http\Controllers\TempUploadController;
 use App\Http\Controllers\TenderController;
 use App\Http\Controllers\UserKeywordController;
+use App\Http\Controllers\UserProfileController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -265,10 +268,26 @@ Route::middleware('auth')->group(function () {
 });
 
 // ========================================================================
-// SEARCH ROUTES
+// USER PROFILE ROUTES
 // ========================================================================
 
-use App\Http\Controllers\SearchController;
+Route::get('/users/{user}', [UserProfileController::class, 'show'])->name('users.show');
+
+// ========================================================================
+// SUBSCRIPTION ROUTES
+// ========================================================================
+
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('/subscriptions', [SubscriptionController::class, 'index'])->name('subscriptions.index');
+    Route::post('/subscriptions/users/{user}', [SubscriptionController::class, 'subscribeUser'])->name('subscriptions.users.store');
+    Route::delete('/subscriptions/users/{user}', [SubscriptionController::class, 'unsubscribeUser'])->name('subscriptions.users.destroy');
+    Route::post('/subscriptions/companies/{company}', [SubscriptionController::class, 'subscribeCompany'])->name('subscriptions.companies.store');
+    Route::delete('/subscriptions/companies/{company}', [SubscriptionController::class, 'unsubscribeCompany'])->name('subscriptions.companies.destroy');
+});
+
+// ========================================================================
+// SEARCH ROUTES
+// ========================================================================
 
 Route::get('/search', [SearchController::class, 'index'])->name('search.index');
 Route::get('/search/quick', [SearchController::class, 'quick'])->name('search.quick');

--- a/tests/Feature/SubscriptionTest.php
+++ b/tests/Feature/SubscriptionTest.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Events\UserSubscribed;
+use App\Models\Company;
+use App\Models\Post;
+use App\Models\Subscription;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class SubscriptionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected Company $company;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $this->company = Company::factory()->create([
+            'created_by' => $this->user->id,
+            'is_verified' => true,
+        ]);
+
+        $this->company->assignModerator($this->user, 'owner');
+
+        Storage::fake('public');
+        Queue::fake();
+    }
+
+    public function test_user_can_subscribe_to_another_user(): void
+    {
+        $targetUser = User::factory()->create(['email_verified_at' => now()]);
+
+        $response = $this->actingAs($this->user)
+            ->post(route('subscriptions.users.store', $targetUser));
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('subscriptions', [
+            'subscriber_id' => $this->user->id,
+            'subscribable_type' => User::class,
+            'subscribable_id' => $targetUser->id,
+        ]);
+    }
+
+    public function test_user_can_unsubscribe_from_user(): void
+    {
+        $targetUser = User::factory()->create(['email_verified_at' => now()]);
+
+        Subscription::create([
+            'subscriber_id' => $this->user->id,
+            'subscribable_type' => User::class,
+            'subscribable_id' => $targetUser->id,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->delete(route('subscriptions.users.destroy', $targetUser));
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('subscriptions', [
+            'subscriber_id' => $this->user->id,
+            'subscribable_type' => User::class,
+            'subscribable_id' => $targetUser->id,
+        ]);
+    }
+
+    public function test_user_can_subscribe_to_company(): void
+    {
+        $otherCompany = Company::factory()->create([
+            'created_by' => User::factory()->create()->id,
+            'is_verified' => true,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->post(route('subscriptions.companies.store', $otherCompany));
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('subscriptions', [
+            'subscriber_id' => $this->user->id,
+            'subscribable_type' => Company::class,
+            'subscribable_id' => $otherCompany->id,
+        ]);
+    }
+
+    public function test_user_can_unsubscribe_from_company(): void
+    {
+        $otherCompany = Company::factory()->create([
+            'created_by' => User::factory()->create()->id,
+            'is_verified' => true,
+        ]);
+
+        Subscription::create([
+            'subscriber_id' => $this->user->id,
+            'subscribable_type' => Company::class,
+            'subscribable_id' => $otherCompany->id,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->delete(route('subscriptions.companies.destroy', $otherCompany));
+
+        $response->assertRedirect();
+        $this->assertDatabaseMissing('subscriptions', [
+            'subscriber_id' => $this->user->id,
+            'subscribable_type' => Company::class,
+            'subscribable_id' => $otherCompany->id,
+        ]);
+    }
+
+    public function test_user_cannot_subscribe_to_self(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->post(route('subscriptions.users.store', $this->user));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('error');
+        $this->assertDatabaseMissing('subscriptions', [
+            'subscriber_id' => $this->user->id,
+            'subscribable_type' => User::class,
+            'subscribable_id' => $this->user->id,
+        ]);
+    }
+
+    public function test_double_subscription_is_idempotent(): void
+    {
+        $targetUser = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($this->user)
+            ->post(route('subscriptions.users.store', $targetUser));
+
+        $this->actingAs($this->user)
+            ->post(route('subscriptions.users.store', $targetUser));
+
+        $this->assertDatabaseCount('subscriptions', 1);
+    }
+
+    public function test_subscription_event_is_dispatched(): void
+    {
+        Event::fake([UserSubscribed::class]);
+
+        $targetUser = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($this->user)
+            ->post(route('subscriptions.users.store', $targetUser));
+
+        Event::assertDispatched(UserSubscribed::class);
+    }
+
+    public function test_dashboard_shows_posts_from_subscriptions(): void
+    {
+        $targetUser = User::factory()->create(['email_verified_at' => now()]);
+
+        // Subscribe to targetUser
+        Subscription::create([
+            'subscriber_id' => $this->user->id,
+            'subscribable_type' => User::class,
+            'subscribable_id' => $targetUser->id,
+        ]);
+
+        // Create post by targetUser
+        $post = Post::create([
+            'user_id' => $targetUser->id,
+            'body' => 'Пост от подписки для теста',
+        ]);
+
+        $response = $this->actingAs($this->user)->get(route('dashboard'));
+
+        $response->assertStatus(200);
+        $response->assertSee('Пост от подписки для теста');
+    }
+
+    public function test_dashboard_hides_posts_from_strangers(): void
+    {
+        $stranger = User::factory()->create(['email_verified_at' => now()]);
+
+        // No subscription — stranger's post should not appear
+        Post::create([
+            'user_id' => $stranger->id,
+            'body' => 'Пост от чужого пользователя',
+        ]);
+
+        $response = $this->actingAs($this->user)->get(route('dashboard'));
+
+        $response->assertStatus(200);
+        $response->assertDontSee('Пост от чужого пользователя');
+    }
+
+    public function test_dashboard_shows_friends_of_friends_posts(): void
+    {
+        $friend = User::factory()->create(['email_verified_at' => now()]);
+        $fof = User::factory()->create(['email_verified_at' => now()]);
+
+        // User subscribes to friend
+        Subscription::create([
+            'subscriber_id' => $this->user->id,
+            'subscribable_type' => User::class,
+            'subscribable_id' => $friend->id,
+        ]);
+
+        // Friend subscribes to fof
+        Subscription::create([
+            'subscriber_id' => $friend->id,
+            'subscribable_type' => User::class,
+            'subscribable_id' => $fof->id,
+        ]);
+
+        // fof creates a post
+        Post::create([
+            'user_id' => $fof->id,
+            'body' => 'Пост от друга друга',
+        ]);
+
+        $response = $this->actingAs($this->user)->get(route('dashboard'));
+
+        $response->assertStatus(200);
+        $response->assertSee('Пост от друга друга');
+    }
+
+    public function test_empty_feed_shows_recommended_companies(): void
+    {
+        // No subscriptions — should see recommendations
+        $recommendedCompany = Company::factory()->create([
+            'created_by' => User::factory()->create()->id,
+            'is_verified' => true,
+            'name' => 'Рекомендованная Компания Тест',
+        ]);
+
+        $response = $this->actingAs($this->user)->get(route('dashboard'));
+
+        $response->assertStatus(200);
+        $response->assertSee('Подпишитесь на коллег и компании');
+        $response->assertSee('Рекомендованная Компания Тест');
+    }
+
+    public function test_public_profile_is_accessible(): void
+    {
+        $targetUser = User::factory()->create([
+            'name' => 'Тестовый Профиль',
+            'email_verified_at' => now(),
+        ]);
+
+        $response = $this->get(route('users.show', $targetUser));
+
+        $response->assertStatus(200);
+        $response->assertSee('Тестовый Профиль');
+    }
+
+    public function test_subscriptions_index_page(): void
+    {
+        $targetUser = User::factory()->create(['email_verified_at' => now(), 'name' => 'Подписка Юзер']);
+
+        Subscription::create([
+            'subscriber_id' => $this->user->id,
+            'subscribable_type' => User::class,
+            'subscribable_id' => $targetUser->id,
+        ]);
+
+        $response = $this->actingAs($this->user)->get(route('subscriptions.index'));
+
+        $response->assertStatus(200);
+        $response->assertSee('Подписка Юзер');
+    }
+
+    public function test_is_subscribed_to_helper(): void
+    {
+        $targetUser = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->assertFalse($this->user->isSubscribedTo($targetUser));
+
+        Subscription::create([
+            'subscriber_id' => $this->user->id,
+            'subscribable_type' => User::class,
+            'subscribable_id' => $targetUser->id,
+        ]);
+
+        $this->assertTrue($this->user->isSubscribedTo($targetUser));
+    }
+
+    public function test_guest_cannot_subscribe(): void
+    {
+        $targetUser = User::factory()->create(['email_verified_at' => now()]);
+
+        $response = $this->post(route('subscriptions.users.store', $targetUser));
+
+        $response->assertRedirect(route('login'));
+    }
+}


### PR DESCRIPTION
## Summary

- Полиморфная таблица `subscriptions` — подписка на User и Company одной записью
- Модель `Subscription` + связи `subscriptions()`, `subscribers()`, `isSubscribedTo()` в User/Company
- `SubscriptionController` — подписка/отписка + страница «Мои подписки» (`/subscriptions`)
- Публичный профиль пользователя `UserProfileController` (`/users/{id}`) — аватар, компании, посты, кнопка подписки
- Blade-компонент `subscribe-button` с toggle подписка/отписка (emerald → серый/красный)
- Фильтрация ленты на dashboard: посты от подписок + друзья друзей (2-й уровень)
- Активности фильтруются по прямым подпискам (1-й уровень)
- Рекомендации верифицированных компаний при пустой ленте
- Event `UserSubscribed` + `SendUserSubscribedNotification` listener + database notification
- Кнопка «Подписаться» на странице компании (для авторизованных не-модераторов)
- Исправлен URL пользователей в поиске (`#` → `route('users.show')`)
- Добавлен case `user_subscribed` в уведомления (иконка + текст)
- 15 тестов (все 232 теста проходят)

Closes #89

## NEWS

👥 **Подписки и профили пользователей**

Теперь вы можете подписываться на коллег и компании! Лента на главной странице
показывает только посты от ваших подписок и их друзей — больше никакого шума.
У каждого пользователя появился публичный профиль с аватаром, компаниями и постами.
А если подписок ещё нет — система подскажет интересные компании.

## Test plan

- [ ] Зайти на `/companies/{slug}` → кнопка «Подписаться» видна для не-модераторов
- [ ] Подписаться на компанию → проверить что подписка сохранилась
- [ ] Зайти на `/users/{id}` → публичный профиль с аватаром, компаниями, постами
- [ ] Подписаться на пользователя → лента на dashboard показывает его посты
- [ ] Зайти на `/subscriptions` → список подписок с кнопками отписки
- [ ] Новый пользователь без подписок → рекомендации компаний в ленте
- [ ] Поиск пользователя → клик ведёт на публичный профиль (не `#`)
- [ ] Уведомление о подписке приходит целевому пользователю
- [ ] `php artisan test` — все 232 теста проходят

🤖 Generated with [Claude Code](https://claude.com/claude-code)