### PR TITLE
fix: пакет исправлений по обратной связи (#105–#115)

### DIFF
--- a/.claude/commands/пр.md
+++ b/.claude/commands/пр.md
@@ -1,0 +1,150 @@
+---
+name: пр
+description: PR + merge + deploy + changelog — всё одной командой для Bizzio.ru
+---
+
+# Скилл «пр» — полный цикл: PR → Merge → Deploy
+
+Выполни полный цикл выпуска изменений для Bizzio.ru. Работай автономно, спрашивай только если что-то критически неясно.
+
+## Контекст
+
+Репо: `ShaerWare/BIZZIO`
+Ветка main НЕ защищена (нет CI, нет branch protection). Можно пушить напрямую если изменения мелкие.
+Сервер: `root@37.233.82.55` (SSH ключ: `~/.ssh/bizzio_deploy`)
+Проект на сервере: `/var/www/BIZZIO/`
+Docker контейнер: `my_project_app`
+Changelog: `docs/CHANGELOG_CLAUDE.md`
+
+## Шаги
+
+### 1. Разведка
+
+```
+git status --short
+git branch --show-current
+git log --oneline -5
+git diff --stat
+git diff --cached --stat
+gh issue list --state open --limit 20 --repo ShaerWare/BIZZIO
+```
+
+Определи:
+- Какие файлы изменены (staged + unstaged + untracked)
+- На какой ветке мы (main или feature)
+- Какие open issues связаны с изменениями
+
+### 2. Обнови CHANGELOG (ОБЯЗАТЕЛЬНО)
+
+Запиши краткий отчёт в конец `docs/CHANGELOG_CLAUDE.md`:
+- Дата
+- Что сделано
+- Какие файлы изменены
+- Причина ошибки (если был bugfix)
+
+Это должно быть сделано **до коммита**, чтобы changelog шёл в том же PR.
+
+### 3. Обнови CLAUDE.md (если нужно)
+
+Прочитай `CLAUDE.md` и обнови если:
+- Добавлены новые роуты, контроллеры, модели
+- Изменена структура БД (миграции)
+- Добавлены новые сервисы, события, джобы
+- Изменены конвенции или архитектурные решения
+
+**Пропусти если** изменения мелкие (багфикс, стилевые правки).
+
+### 4. Коммит
+
+Если есть незакоммиченные изменения:
+- `git add` только нужные файлы (не .env, не credentials)
+- Для крупных фич — создай feature branch: `git checkout -b feat/описание` или `fix/описание`
+- Для мелких фиксов — можно коммитить прямо в main
+
+Формат коммита:
+```
+git commit -m "$(cat <<'EOF'
+feat/fix/docs: краткое описание
+
+Детальное описание изменений.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+### 5. Push + PR (для feature-веток)
+
+Если на feature-ветке:
+```
+git push -u origin <ветка>
+```
+
+Создай PR через `gh pr create --repo ShaerWare/BIZZIO`:
+- `--title` — короткий (до 70 символов)
+- `--body` содержит:
+  - `## Summary` — буллеты с изменениями
+  - `Closes #N` для каждого решённого issue
+  - `Relates to #N` если issue не полностью решается
+  - `## Test plan` — чеклист проверки
+  - `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+
+Замерджь сразу (нет CI):
+```
+gh pr merge <PR_NUMBER> --merge --repo ShaerWare/BIZZIO
+```
+
+Вернись на main:
+```
+git checkout main && git pull origin main
+git branch -D <ветка>
+git push origin --delete <ветка>
+```
+
+Если коммитил прямо в main — просто `git push origin main`.
+
+### 6. Deploy production
+
+SSH на сервер и выполни деплой:
+```bash
+ssh -i ~/.ssh/bizzio_deploy root@37.233.82.55 "cd /var/www/BIZZIO && \
+  git pull origin main && \
+  docker compose exec -T app composer install --no-dev --optimize-autoloader && \
+  docker compose exec -T app php artisan migrate --force && \
+  docker compose exec -T app php artisan config:cache && \
+  docker compose exec -T app php artisan route:cache && \
+  docker compose exec -T app php artisan view:cache && \
+  docker compose exec -T app php artisan queue:restart"
+```
+
+Проверь что сайт работает:
+```bash
+ssh -i ~/.ssh/bizzio_deploy root@37.233.82.55 "curl -sI https://bizzio.ru | head -5"
+```
+
+Ожидаемый ответ: `HTTP/2 200`
+
+Если 502 — проверь Docker:
+```bash
+ssh -i ~/.ssh/bizzio_deploy root@37.233.82.55 "cd /var/www/BIZZIO && docker compose ps && docker compose logs --tail=20 app"
+```
+
+### 7. Закрой issues
+
+Проверь что issues закрылись автоматически (через `Closes #N` в PR):
+```
+gh issue view <N> --json state -q '.state' --repo ShaerWare/BIZZIO
+```
+
+Если issue не закрылось — закрой вручную:
+```
+gh issue close <N> --comment "Done in PR #<PR_NUMBER>" --repo ShaerWare/BIZZIO
+```
+
+### 8. Финальный отчёт
+
+Выведи пользователю:
+- Номер PR и ссылку (или «прямой push в main»)
+- Какие issues закрыты
+- Статус деплоя (200 / ошибка)
+- Что изменено (кратко)

--- a/app/Http/Controllers/AuctionController.php
+++ b/app/Http/Controllers/AuctionController.php
@@ -85,6 +85,7 @@ class AuctionController extends Controller
                 'starting_price' => $request->starting_price,
                 'step_percent' => 2.5, // A4: Фиксированный диапазон 0.5-5%, среднее значение для совместимости
                 'status' => $request->status ?? 'draft',
+                'is_results_hidden' => $request->boolean('is_results_hidden'),
             ]);
             
             // F3: Загрузка технического задания с поддержкой temp-файлов
@@ -172,14 +173,24 @@ class AuctionController extends Controller
         
         $currentPrice = $auction->getCurrentPrice();
         $stepRange = $auction->getStepRange();
-        
+
+        // #115: Определяем, может ли пользователь видеть результаты
+        $canSeeResults = true;
+        if ($auction->is_results_hidden && in_array($auction->status, ['closed', 'cancelled'])) {
+            $isManager = auth()->check() && $auction->canManage(auth()->user());
+            $isParticipant = auth()->check() && $auction->bids->pluck('company_id')
+                ->intersect($userCompanies->pluck('id'))->isNotEmpty();
+            $canSeeResults = $isManager || $isParticipant;
+        }
+
         return view('auctions.show', compact(
             'auction',
             'canBid',
             'userCompanies',
             'existingBid',
             'currentPrice',
-            'stepRange'
+            'stepRange',
+            'canSeeResults'
         ));
     }
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -116,19 +116,49 @@ class DashboardController extends Controller
             ->take(3)
             ->get();
 
-        $myTenders = collect($myRfqs->map(fn ($r) => [
-            'type' => 'rfq',
-            'title' => $r->title,
-            'number' => $r->number,
-            'status' => $r->status,
-            'url' => route('rfqs.show', $r),
-        ]))->merge($myAuctions->map(fn ($a) => [
-            'type' => 'auction',
-            'title' => $a->title,
-            'number' => $a->number,
-            'status' => $a->status,
-            'url' => route('auctions.show', $a),
-        ]))->sortByDesc('number')->take(3)->values();
+        $statusInfo = function (string $status, $startDate, $endDate, string $type) {
+            if ($status === 'active') {
+                if ($startDate && $startDate->isFuture()) {
+                    return ['Скоро', 'bg-yellow-100 text-yellow-800'];
+                } elseif ($endDate && $endDate->isPast()) {
+                    return [$type === 'rfq' ? 'Подведение итогов' : 'Завершён приём', 'bg-orange-100 text-orange-800'];
+                }
+
+                return ['Приём заявок', 'bg-green-100 text-green-800'];
+            }
+
+            return match ($status) {
+                'trading' => ['Торги', 'bg-emerald-100 text-emerald-800'],
+                'closed' => ['Завершён', 'bg-gray-100 text-gray-800'],
+                'cancelled' => ['Отменён', 'bg-red-100 text-red-800'],
+                'draft' => ['Черновик', 'bg-yellow-100 text-yellow-800'],
+                default => [$status, 'bg-gray-100 text-gray-800'],
+            };
+        };
+
+        $myTenders = collect($myRfqs->map(function ($r) use ($statusInfo) {
+            [$label, $color] = $statusInfo($r->status, $r->start_date, $r->end_date, 'rfq');
+
+            return [
+                'type' => 'rfq',
+                'title' => $r->title,
+                'number' => $r->number,
+                'status_label' => $label,
+                'status_color' => $color,
+                'url' => route('rfqs.show', $r),
+            ];
+        }))->merge($myAuctions->map(function ($a) use ($statusInfo) {
+            [$label, $color] = $statusInfo($a->status, $a->start_date, $a->end_date, 'auction');
+
+            return [
+                'type' => 'auction',
+                'title' => $a->title,
+                'number' => $a->number,
+                'status_label' => $label,
+                'status_color' => $color,
+                'url' => route('auctions.show', $a),
+            ];
+        }))->sortByDesc('number')->take(3)->values();
 
         $rfqInvitations = RfqInvitation::whereIn('company_id', $companyIds)
             ->with('rfq')
@@ -142,19 +172,41 @@ class DashboardController extends Controller
             ->take(3)
             ->get();
 
-        $myInvitations = collect($rfqInvitations->map(fn ($i) => [
-            'type' => 'rfq',
-            'title' => $i->rfq->title ?? '',
-            'number' => $i->rfq->number ?? '',
-            'status' => $i->status,
-            'url' => route('rfqs.show', $i->rfq_id),
-        ]))->merge($auctionInvitations->map(fn ($i) => [
-            'type' => 'auction',
-            'title' => $i->auction->title ?? '',
-            'number' => $i->auction->number ?? '',
-            'status' => $i->status,
-            'url' => route('auctions.show', $i->auction_id),
-        ]))->take(3)->values();
+        $invitationStatusLabels = [
+            'pending' => ['Ожидает', 'bg-yellow-100 text-yellow-800'],
+            'accepted' => ['Принято', 'bg-green-100 text-green-800'],
+            'declined' => ['Отклонено', 'bg-red-100 text-red-800'],
+        ];
+
+        $myInvitations = collect($rfqInvitations->map(function ($i) use ($statusInfo, $invitationStatusLabels) {
+            [$tenderLabel, $tenderColor] = $statusInfo($i->rfq->status ?? 'draft', $i->rfq->start_date ?? null, $i->rfq->end_date ?? null, 'rfq');
+            [$invLabel, $invColor] = $invitationStatusLabels[$i->status] ?? ['—', 'bg-gray-100 text-gray-800'];
+
+            return [
+                'type' => 'rfq',
+                'title' => $i->rfq->title ?? '',
+                'number' => $i->rfq->number ?? '',
+                'inv_label' => $invLabel,
+                'inv_color' => $invColor,
+                'tender_label' => $tenderLabel,
+                'tender_color' => $tenderColor,
+                'url' => route('rfqs.show', $i->rfq_id),
+            ];
+        }))->merge($auctionInvitations->map(function ($i) use ($statusInfo, $invitationStatusLabels) {
+            [$tenderLabel, $tenderColor] = $statusInfo($i->auction->status ?? 'draft', $i->auction->start_date ?? null, $i->auction->end_date ?? null, 'auction');
+            [$invLabel, $invColor] = $invitationStatusLabels[$i->status] ?? ['—', 'bg-gray-100 text-gray-800'];
+
+            return [
+                'type' => 'auction',
+                'title' => $i->auction->title ?? '',
+                'number' => $i->auction->number ?? '',
+                'inv_label' => $invLabel,
+                'inv_color' => $invColor,
+                'tender_label' => $tenderLabel,
+                'tender_color' => $tenderColor,
+                'url' => route('auctions.show', $i->auction_id),
+            ];
+        }))->take(3)->values();
 
         $rfqBids = RfqBid::whereIn('company_id', $companyIds)
             ->with('rfq')
@@ -173,12 +225,14 @@ class DashboardController extends Controller
             'title' => $b->rfq->title ?? '',
             'number' => $b->rfq->number ?? '',
             'price' => $b->price,
+            'currency_symbol' => $b->rfq->currency_symbol ?? '₽',
             'url' => route('rfqs.show', $b->rfq_id),
         ]))->merge($auctionBids->map(fn ($b) => [
             'type' => 'auction',
             'title' => $b->auction->title ?? '',
             'number' => $b->auction->number ?? '',
             'price' => $b->price,
+            'currency_symbol' => $b->auction->currency_symbol ?? '₽',
             'url' => route('auctions.show', $b->auction_id),
         ]))->take(3)->values();
 

--- a/app/Http/Controllers/RfqController.php
+++ b/app/Http/Controllers/RfqController.php
@@ -104,6 +104,7 @@ class RfqController extends Controller
                 'weight_deadline' => $request->weight_deadline,
                 'weight_advance' => $request->weight_advance,
                 'status' => $request->status ?? 'draft', // ✅ ИСПОЛЬЗУЕМ СТАТУС ИЗ ФОРМЫ
+                'is_results_hidden' => $request->boolean('is_results_hidden'),
             ]);
 
             // Загрузка технического задания (PDF) - F3: поддержка temp-файлов
@@ -229,7 +230,16 @@ class RfqController extends Controller
             }
         }
 
-        return view('rfqs.show', compact('rfq', 'canBid', 'alreadyBid', 'availableCompanies'));
+        // #115: Определяем, может ли пользователь видеть результаты
+        $canSeeResults = true;
+        if ($rfq->is_results_hidden && $rfq->status === 'closed') {
+            $isManager = auth()->check() && $rfq->canManage(auth()->user());
+            $isParticipant = auth()->check() && $rfq->bids->pluck('company_id')
+                ->intersect($userCompanies->pluck('id'))->isNotEmpty();
+            $canSeeResults = $isManager || $isParticipant;
+        }
+
+        return view('rfqs.show', compact('rfq', 'canBid', 'alreadyBid', 'availableCompanies', 'canSeeResults'));
     }
 
     /**

--- a/app/Http/Requests/StoreAuctionRequest.php
+++ b/app/Http/Requests/StoreAuctionRequest.php
@@ -44,6 +44,7 @@ class StoreAuctionRequest extends FormRequest
             'invited_companies' => ['nullable', 'array'],
             'invited_companies.*' => ['exists:companies,id'],
             'notification_agreement' => ['required', 'accepted'],
+            'is_results_hidden' => ['nullable', 'boolean'],
         ];
     }
 

--- a/app/Http/Requests/StoreRfqRequest.php
+++ b/app/Http/Requests/StoreRfqRequest.php
@@ -38,6 +38,7 @@ class StoreRfqRequest extends FormRequest
             'technical_specification_temp' => 'nullable|string',
             'invited_companies' => 'nullable|array',
             'invited_companies.*' => 'exists:companies,id',
+            'is_results_hidden' => 'nullable|boolean',
         ];
     }
 

--- a/app/Http/Requests/UpdateAuctionRequest.php
+++ b/app/Http/Requests/UpdateAuctionRequest.php
@@ -29,14 +29,23 @@ class UpdateAuctionRequest extends FormRequest
             'description' => ['nullable', 'string'],
             'end_date' => ['required', 'date', 'after:start_date'],
             'trading_start' => ['required', 'date', 'after:end_date'],
+            'currency' => ['required', 'string', Rule::in(array_keys(\App\Models\Auction::CURRENCIES))],
             'starting_price' => ['required', 'numeric', 'min:1'],
             'technical_specification' => ['nullable', 'file', 'mimes:pdf', 'max:10240'],
+            'is_results_hidden' => ['nullable', 'boolean'],
         ];
     }
 
     /**
      * Get custom validation messages.
      */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'is_results_hidden' => $this->boolean('is_results_hidden'),
+        ]);
+    }
+
     public function messages(): array
     {
         return [

--- a/app/Http/Requests/UpdateRfqRequest.php
+++ b/app/Http/Requests/UpdateRfqRequest.php
@@ -29,12 +29,20 @@ class UpdateRfqRequest extends FormRequest
             'end_date' => ['sometimes', 'required', 'date', 'after:' . $this->route('rfq')->start_date],
             'technical_specification' => 'nullable|file|mimes:pdf|max:10240',
             'technical_specification_temp' => 'nullable|string',
+            'is_results_hidden' => 'nullable|boolean',
         ];
     }
 
     /**
      * Кастомные сообщения об ошибках
      */
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'is_results_hidden' => $this->boolean('is_results_hidden'),
+        ]);
+    }
+
     public function messages(): array
     {
         return [

--- a/app/Models/Auction.php
+++ b/app/Models/Auction.php
@@ -37,10 +37,12 @@ class Auction extends Model implements HasMedia
         'step_percent',
         'last_bid_at',
         'status',
+        'is_results_hidden',
         'winner_bid_id',
     ];
 
     protected $casts = [
+        'is_results_hidden' => 'boolean',
         'start_date' => 'datetime',
         'end_date' => 'datetime',
         'trading_start' => 'datetime',

--- a/app/Models/Rfq.php
+++ b/app/Models/Rfq.php
@@ -35,6 +35,7 @@ class Rfq extends Model implements HasMedia
         'weight_deadline',
         'weight_advance',
         'status',
+        'is_results_hidden',
         'winner_bid_id',
     ];
 
@@ -44,6 +45,7 @@ class Rfq extends Model implements HasMedia
         'weight_price' => 'decimal:2',
         'weight_deadline' => 'decimal:2',
         'weight_advance' => 'decimal:2',
+        'is_results_hidden' => 'boolean',
     ];
 
     public const CURRENCIES = [

--- a/database/migrations/2026_03_14_160109_add_is_results_hidden_to_auctions_and_rfqs_table.php
+++ b/database/migrations/2026_03_14_160109_add_is_results_hidden_to_auctions_and_rfqs_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('auctions', function (Blueprint $table) {
+            $table->boolean('is_results_hidden')->default(false)->after('status');
+        });
+
+        Schema::table('rfqs', function (Blueprint $table) {
+            $table->boolean('is_results_hidden')->default(false)->after('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('auctions', function (Blueprint $table) {
+            $table->dropColumn('is_results_hidden');
+        });
+
+        Schema::table('rfqs', function (Blueprint $table) {
+            $table->dropColumn('is_results_hidden');
+        });
+    }
+};

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -4,6 +4,41 @@
 
 ---
 
+## 2026-03-14 — Пакет исправлений по обратной связи заказчика (Issues #105–#115)
+
+### Issue #112 — Валюта в виджете ставок на дашборде
+Заменён хардкод `₽` на `currency_symbol` из модели. Файлы: `DashboardController.php`, `bids-widget.blade.php`.
+
+### Issue #111 — Статусы тендеров в виджете «Мои тендеры»
+Добавлены человекочитаемые метки статусов с цветовыми индикаторами (Приём заявок, Торги, Завершён и т.д.). Файлы: `DashboardController.php`, `tenders-widget.blade.php`.
+
+### Issue #110 — Статусы приглашений в виджете
+Добавлены цветные бейджи: тип тендера, статус приглашения, статус тендера. Файлы: `DashboardController.php`, `invitations-widget.blade.php`.
+
+### Issue #109 — Скрытие вкладки ставок в аукционе до завершения
+Вкладка «Ставки» показывается только при `closed`/`cancelled`. Файл: `auctions/show.blade.php`.
+
+### Issue #108 — Адаптивность страницы компании
+Шапка компании сделана респонсивной (flex-col/row, адаптивные размеры лого и кнопок). Файл: `companies/show.blade.php`.
+
+### Issue #107 — Перевод welcome-страницы + якорь на форму логина
+Кнопка «Войти» в шапке скроллит к форме. Английский текст переведён на русский. Файл: `welcome.blade.php`.
+
+### Issue #106 — Редактирование валюты аукциона
+Добавлен select валюты + динамическое обновление символа в label цены. Файлы: `auctions/edit.blade.php`, `UpdateAuctionRequest.php`.
+
+### Issue #105 — Адаптивность карточек заявок на вступление
+Сделана респонсивная раскладка для карточек join request. Файл: `companies/show.blade.php`.
+
+### Issue #115 — Скрытие результатов завершённых тендеров
+- Новая миграция: `is_results_hidden` (boolean) для таблиц `auctions` и `rfqs`
+- Поле добавлено в модели, формы создания/редактирования (чекбокс), валидацию запросов
+- Логика скрытия в контроллерах: если флаг включён и тендер завершён — результаты (заявки, протокол) видны только организатору и участникам
+- Бейдж «Результаты скрыты» на странице тендера
+- Файлы: миграция, `Auction.php`, `Rfq.php`, `AuctionController.php`, `RfqController.php`, `Store/UpdateAuction/RfqRequest.php`, все create/edit blade-файлы для аукционов и RFQ, оба show blade-файла
+
+---
+
 ## 2026-03-05 — Фикс регистрации: reCAPTCHA блокировала форму
 
 **Проблема:** Регистрация новых пользователей невозможна. Валидация требовала поле `g-recaptcha-response` как `required`, но виджет reCAPTCHA не отображался (ключи `RECAPTCHA_SITE_KEY` / `RECAPTCHA_SECRET_KEY` пустые на сервере). Форма всегда падала с ошибкой валидации.
@@ -1102,3 +1137,15 @@ SESSION_SECURE_COOKIE=true
 - `resources/views/layouts/navigation.blade.php` — объединённое меню (desktop + mobile)
 - `resources/views/components/rfq-card.blade.php` — бейдж «Запрос котировок»
 - `resources/views/components/auction-card.blade.php` — бейдж «Аукцион»
+
+---
+
+### 2026-03-14 — Фикс 502 ошибки на продакшене
+
+**Проблема:** Сайт bizzio.ru возвращал 502. Caddy-контейнер не мог зарезолвить хост `app` (`dial tcp: lookup app on 127.0.0.11:53: no such host`).
+
+**Причина:** Caddy оказался только в сети `docker_default`, а app-контейнер — в `bizzio_app-network`. Контейнеры были в разных Docker-сетях и не видели друг друга. Вероятно, Caddy был пересоздан без учёта `docker-compose.override.yml`.
+
+**Решение:** Пересоздан Caddy-контейнер: `docker compose up -d --force-recreate caddy`. Теперь он корректно подключён к обеим сетям (`bizzio_app-network` + `docker_default`), как прописано в override.
+
+**Изменённые файлы:** нет (операция на сервере)

--- a/resources/views/auctions/create.blade.php
+++ b/resources/views/auctions/create.blade.php
@@ -330,6 +330,21 @@
                         @enderror
                     </div>
 
+                    <!-- Скрытие результатов после завершения -->
+                    <div class="mb-6">
+                        <label class="inline-flex items-center">
+                            <input type="checkbox"
+                                   name="is_results_hidden"
+                                   value="1"
+                                   {{ old('is_results_hidden') ? 'checked' : '' }}
+                                   class="rounded border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
+                            <span class="ml-2 text-sm text-gray-700">
+                                Скрыть результаты после завершения
+                                <span class="text-gray-500">(видны только организатору и участникам)</span>
+                            </span>
+                        </label>
+                    </div>
+
                     <!-- Предупреждение при выборе "Опубликовать сразу" -->
                     <div id="status-warning" class="mb-6 p-4 bg-yellow-50 border-l-4 border-yellow-400 hidden">
                         <div class="flex">

--- a/resources/views/auctions/edit.blade.php
+++ b/resources/views/auctions/edit.blade.php
@@ -79,10 +79,31 @@
                         <p class="mt-1 text-xs text-gray-500">UTC +3 (Москва). Текущее значение: {{ $auction->trading_start->format('d.m.Y H:i') }}</p>
                     </div>
 
+                    <!-- Валюта -->
+                    <div class="mb-6">
+                        <label for="currency" class="block text-sm font-medium text-gray-700 mb-2">
+                            Валюта <span class="text-red-500">*</span>
+                        </label>
+                        <select name="currency"
+                                id="currency"
+                                required
+                                onchange="updateCurrencyLabel()"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 @error('currency') border-red-500 @enderror">
+                            @foreach(\App\Models\Auction::CURRENCIES as $code => $symbol)
+                                <option value="{{ $code }}" {{ old('currency', $auction->currency) === $code ? 'selected' : '' }}>
+                                    {{ $code }} ({{ $symbol }})
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('currency')
+                            <p class="mt-1 text-sm text-red-600">{{ $message }}</p>
+                        @enderror
+                    </div>
+
                     <!-- Начальная максимальная цена -->
                     <div class="mb-6">
                         <label for="starting_price" class="block text-sm font-medium text-gray-700 mb-2">
-                            Начальная максимальная цена ({{ $auction->currency_symbol }}) <span class="text-red-500">*</span>
+                            Начальная максимальная цена (<span id="currency-symbol">{{ $auction->currency_symbol }}</span>) <span class="text-red-500">*</span>
                         </label>
                         <input type="number"
                                name="starting_price"
@@ -134,6 +155,21 @@
                         @enderror
                     </div>
 
+                    <!-- Скрытие результатов после завершения -->
+                    <div class="mb-6">
+                        <label class="inline-flex items-center">
+                            <input type="checkbox"
+                                   name="is_results_hidden"
+                                   value="1"
+                                   {{ old('is_results_hidden', $auction->is_results_hidden) ? 'checked' : '' }}
+                                   class="rounded border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
+                            <span class="ml-2 text-sm text-gray-700">
+                                Скрыть результаты после завершения
+                                <span class="text-gray-500">(видны только организатору и участникам)</span>
+                            </span>
+                        </label>
+                    </div>
+
                     <!-- Кнопки -->
                     <div class="flex justify-between items-center">
                         <a href="{{ route('auctions.show', $auction) }}" 
@@ -172,6 +208,14 @@
             });
         }
     });
+
+    // Обновление символа валюты в label цены
+    const currencySymbols = {!! json_encode(\App\Models\Auction::CURRENCIES) !!};
+    function updateCurrencyLabel() {
+        const sel = document.getElementById('currency');
+        const span = document.getElementById('currency-symbol');
+        if (sel && span) span.textContent = currencySymbols[sel.value] || '₽';
+    }
 </script>
 @endpush
 @endsection

--- a/resources/views/auctions/show.blade.php
+++ b/resources/views/auctions/show.blade.php
@@ -128,6 +128,11 @@
                                     Закрытие через {{ Carbon\Carbon::parse($auction->last_bid_at)->addMinutes(20)->diffForHumans() }}
                                 </span>
                             @endif
+                            @if($auction->is_results_hidden)
+                                <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800">
+                                    Результаты скрыты
+                                </span>
+                            @endif
                         </div>
 
                         <!-- Компания-организатор -->
@@ -202,7 +207,7 @@
                         @endif
 
                         <!-- Протокол (если завершён) — A16: доступ только организатору и участникам -->
-                        @if($auction->status === 'closed')
+                        @if($auction->status === 'closed' && $canSeeResults)
                             @php
                                 $isParticipant = auth()->check() && $auction->bids->pluck('company_id')->intersect($userCompanies->pluck('id'))->isNotEmpty();
                                 $isManager = auth()->check() && $auction->canManage(auth()->user());
@@ -429,15 +434,13 @@
                             class="tab-button active border-emerald-500 text-emerald-600 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
                         Описание
                     </button>
-                    <button onclick="showTab('bids')" 
+                    @if(($auction->status === 'closed' || $auction->status === 'cancelled') && $canSeeResults)
+                    <button onclick="showTab('bids')"
                             id="tab-bids"
                             class="tab-button border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
-                        @if($auction->status === 'active')
-                            Заявки ({{ $auction->initialBids->count() }})
-                        @else
-                            Ставки ({{ $auction->tradingBids->count() }})
-                        @endif
+                        Ставки ({{ $auction->tradingBids->count() }})
                     </button>
+                    @endif
                     @if($auction->type === 'closed')
                         <button onclick="showTab('invitations')" 
                                 id="tab-invitations"
@@ -461,8 +464,20 @@
                     @endif
                 </div>
 
-                <!-- Вкладка: Заявки/Ставки -->
-                <div id="content-bids" class="tab-content hidden">
+                <!-- Вкладка: Ставки (видна только при closed/cancelled и если результаты не скрыты) -->
+                @if(!$canSeeResults && in_array($auction->status, ['closed', 'cancelled']))
+                    <div class="tab-content hidden" id="content-bids-hidden">
+                        <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center">
+                            <svg class="w-10 h-10 text-yellow-500 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L6.05 6.05m3.828 3.828l4.242 4.242M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3l18 18"></path>
+                            </svg>
+                            <p class="text-yellow-800 font-medium">Результаты скрыты организатором</p>
+                            <p class="text-yellow-600 text-sm mt-1">Результаты видны только организатору и участникам</p>
+                        </div>
+                    </div>
+                @endif
+                <div id="content-bids" class="tab-content hidden" @if(!$canSeeResults || !in_array($auction->status, ['closed', 'cancelled'])) style="display:none!important" @endif>
 
                     <!-- Форма подачи заявки/ставки -->
                     @auth

--- a/resources/views/companies/show.blade.php
+++ b/resources/views/companies/show.blade.php
@@ -27,14 +27,14 @@
         <!-- Заголовок с кнопками -->
         <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg mb-6">
             <div class="p-6">
-                <div class="flex justify-between items-start">
-                    <div class="flex items-start space-x-4 flex-1">
+                <div class="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4">
+                    <div class="flex items-start space-x-3 sm:space-x-4 flex-1 min-w-0">
                         @if($company->logo)
                             <img src="{{ Storage::url($company->logo) }}" 
                                  alt="{{ $company->name }}"
-                                 class="w-24 h-24 rounded-lg object-cover shadow-md">
+                                 class="w-16 h-16 sm:w-24 sm:h-24 rounded-lg object-cover shadow-md flex-shrink-0">
                         @else
-                            <div class="w-24 h-24 bg-gradient-to-br from-emerald-500 to-purple-600 rounded-lg flex items-center justify-center shadow-md">
+                            <div class="w-16 h-16 sm:w-24 sm:h-24 bg-gradient-to-br from-emerald-500 to-purple-600 rounded-lg flex items-center justify-center shadow-md flex-shrink-0">
                                 <span class="text-4xl font-bold text-white">
                                     {{ substr($company->name, 0, 1) }}
                                 </span>
@@ -42,8 +42,8 @@
                         @endif
 
                         <div class="flex-1">
-                            <div class="flex items-center space-x-3 mb-2">
-                                <h1 class="text-3xl font-bold text-gray-900">{{ $company->name }}</h1>
+                            <div class="flex items-center flex-wrap gap-2 mb-2">
+                                <h1 class="text-xl sm:text-3xl font-bold text-gray-900 break-words">{{ $company->name }}</h1>
                                 @if($company->is_verified)
                                     <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
                                         <svg class="w-4 h-4 mr-1" fill="currentColor" viewBox="0 0 20 20">
@@ -82,7 +82,7 @@
                     </div>
 
                     <!-- Кнопки действий -->
-                    <div class="flex space-x-2 ml-4">
+                    <div class="flex flex-wrap gap-2">
                         @auth
                             @unless($company->isModerator(auth()->user()))
                                 @include('components.subscribe-button', ['target' => $company])
@@ -372,9 +372,9 @@
                                     <div class="space-y-4">
                                         @foreach($pendingRequests as $joinRequest)
                                             <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-                                                <div class="flex items-start justify-between">
-                                                    <div class="flex items-start flex-1">
-                                                        <div class="w-12 h-12 rounded-full bg-emerald-100 flex items-center justify-center mr-4">
+                                                <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+                                                    <div class="flex items-start flex-1 min-w-0">
+                                                        <div class="w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-emerald-100 flex items-center justify-center mr-3 sm:mr-4 flex-shrink-0">
                                                             <span class="text-lg font-semibold text-emerald-600">
                                                                 {{ strtoupper(substr($joinRequest->user->name, 0, 2)) }}
                                                             </span>
@@ -407,7 +407,7 @@
                                                     </div>
 
                                                     <!-- Кнопки действий -->
-                                                    <div class="flex space-x-2 ml-4">
+                                                    <div class="flex gap-2 sm:ml-4">
                                                         <button onclick="showApproveModal({{ $joinRequest->id }}, {{ Js::from($joinRequest->user->name) }}, {{ Js::from($joinRequest->desired_role) }})"
                                                                 class="inline-flex items-center px-3 py-2 bg-green-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-green-700 transition">
                                                             Одобрить

--- a/resources/views/partials/dashboard/bids-widget.blade.php
+++ b/resources/views/partials/dashboard/bids-widget.blade.php
@@ -12,7 +12,7 @@
                             <span class="text-xs px-1.5 py-0.5 rounded {{ $bid['type'] === 'rfq' ? 'bg-yellow-100 text-yellow-800' : 'bg-purple-100 text-purple-800' }}">
                                 {{ $bid['type'] === 'rfq' ? 'ЗЦ' : 'Аукцион' }}
                             </span>
-                            <span class="text-xs text-gray-500">{{ number_format($bid['price'], 0, ',', ' ') }} ₽</span>
+                            <span class="text-xs text-gray-500">{{ number_format($bid['price'], 0, ',', ' ') }} {{ $bid['currency_symbol'] }}</span>
                         </div>
                     </li>
                 @endforeach

--- a/resources/views/partials/dashboard/invitations-widget.blade.php
+++ b/resources/views/partials/dashboard/invitations-widget.blade.php
@@ -8,11 +8,12 @@
                         <a href="{{ $inv['url'] }}" class="text-gray-700 hover:text-emerald-600 block truncate">
                             {{ $inv['title'] ?: $inv['number'] }}
                         </a>
-                        <div class="flex items-center space-x-2 mt-0.5">
+                        <div class="flex items-center flex-wrap gap-1 mt-0.5">
                             <span class="text-xs px-1.5 py-0.5 rounded {{ $inv['type'] === 'rfq' ? 'bg-yellow-100 text-yellow-800' : 'bg-purple-100 text-purple-800' }}">
                                 {{ $inv['type'] === 'rfq' ? 'ЗЦ' : 'Аукцион' }}
                             </span>
-                            <span class="text-xs text-gray-500">{{ $inv['status'] }}</span>
+                            <span class="text-xs px-1.5 py-0.5 rounded {{ $inv['inv_color'] }}">{{ $inv['inv_label'] }}</span>
+                            <span class="text-xs px-1.5 py-0.5 rounded {{ $inv['tender_color'] }}">{{ $inv['tender_label'] }}</span>
                         </div>
                     </li>
                 @endforeach

--- a/resources/views/partials/dashboard/tenders-widget.blade.php
+++ b/resources/views/partials/dashboard/tenders-widget.blade.php
@@ -12,7 +12,7 @@
                             <span class="text-xs px-1.5 py-0.5 rounded {{ $tender['type'] === 'rfq' ? 'bg-yellow-100 text-yellow-800' : 'bg-purple-100 text-purple-800' }}">
                                 {{ $tender['type'] === 'rfq' ? 'ЗЦ' : 'Аукцион' }}
                             </span>
-                            <span class="text-xs text-gray-500">{{ $tender['status'] }}</span>
+                            <span class="text-xs px-1.5 py-0.5 rounded {{ $tender['status_color'] }}">{{ $tender['status_label'] }}</span>
                         </div>
                     </li>
                 @endforeach

--- a/resources/views/rfqs/create.blade.php
+++ b/resources/views/rfqs/create.blade.php
@@ -356,6 +356,21 @@
                         </label>
                     </div>
 
+                    <!-- Скрытие результатов после завершения -->
+                    <div class="mb-6">
+                        <label class="inline-flex items-center">
+                            <input type="checkbox"
+                                   name="is_results_hidden"
+                                   value="1"
+                                   {{ old('is_results_hidden') ? 'checked' : '' }}
+                                   class="rounded border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
+                            <span class="ml-2 text-sm text-gray-700">
+                                Скрыть результаты после завершения
+                                <span class="text-gray-500">(видны только организатору и участникам)</span>
+                            </span>
+                        </label>
+                    </div>
+
                     <!-- Кнопки -->
                     <div class="flex justify-between items-center">
                         <a href="{{ route('rfqs.index') }}" 

--- a/resources/views/rfqs/edit.blade.php
+++ b/resources/views/rfqs/edit.blade.php
@@ -100,6 +100,21 @@
                         @enderror
                     </div>
 
+                    <!-- Скрытие результатов после завершения -->
+                    <div class="mb-6">
+                        <label class="inline-flex items-center">
+                            <input type="checkbox"
+                                   name="is_results_hidden"
+                                   value="1"
+                                   {{ old('is_results_hidden', $rfq->is_results_hidden) ? 'checked' : '' }}
+                                   class="rounded border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
+                            <span class="ml-2 text-sm text-gray-700">
+                                Скрыть результаты после завершения
+                                <span class="text-gray-500">(видны только организатору и участникам)</span>
+                            </span>
+                        </label>
+                    </div>
+
                     <!-- Кнопки -->
                     <div class="flex justify-between items-center">
                         <a href="{{ route('rfqs.show', $rfq) }}"

--- a/resources/views/rfqs/show.blade.php
+++ b/resources/views/rfqs/show.blade.php
@@ -90,6 +90,11 @@
                             <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium {{ $rfq->type === 'open' ? 'bg-emerald-100 text-emerald-800' : 'bg-purple-100 text-purple-800' }}">
                                 {{ $rfq->type === 'open' ? 'Открытая процедура' : 'Закрытая процедура' }}
                             </span>
+                            @if($rfq->is_results_hidden)
+                                <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800">
+                                    Результаты скрыты
+                                </span>
+                            @endif
                         </div>
 
                         <!-- Компания-организатор -->
@@ -498,7 +503,16 @@
                     @endif
 
                     <!-- Список заявок -->
-                    @if($rfq->bids->count() > 0)
+                    @if(!$canSeeResults && $rfq->status === 'closed')
+                        <div class="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center">
+                            <svg class="w-10 h-10 text-yellow-500 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L6.05 6.05m3.828 3.828l4.242 4.242M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3l18 18"></path>
+                            </svg>
+                            <p class="text-yellow-800 font-medium">Результаты скрыты организатором</p>
+                            <p class="text-yellow-600 text-sm mt-1">Результаты видны только организатору и участникам</p>
+                        </div>
+                    @elseif($rfq->bids->count() > 0)
                         @php
                             // T2: Определяем компании текущего пользователя для подсветки его заявок
                             $userCompanyIds = auth()->check() && isset($availableCompanies) ? $availableCompanies->pluck('id')->toArray() : [];
@@ -584,7 +598,7 @@
                     @endif
 
                     <!-- Протокол (если завершён) — A16: доступ только организатору и участникам -->
-                    @if($rfq->status === 'closed' && $rfq->hasMedia('protocol'))
+                    @if($canSeeResults && $rfq->status === 'closed' && $rfq->hasMedia('protocol'))
                         @php
                             $rfqIsParticipant = auth()->check() && isset($availableCompanies) && $rfq->bids->pluck('company_id')->intersect($availableCompanies->pluck('id'))->isNotEmpty();
                             $rfqIsManager = auth()->check() && $rfq->canManage(auth()->user());

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -72,8 +72,8 @@
                 <!-- User Navigation -->
                 <ul class="navbar-nav navbar-user">
                     @guest
-                        <li><a href="{{ route('login') }}" class="nav-link">Login</a></li> <!-- ИСПРАВЛЕНО: убран data-bs-toggle -->
-                        <li><a href="{{ route('register') }}" class="nav-link">Register</a></li>
+                        <li><a href="#login-form" class="nav-link" onclick="document.getElementById('login-form').scrollIntoView({behavior:'smooth'});return false;">Войти</a></li>
+                        <li><a href="{{ route('register') }}" class="nav-link">Регистрация</a></li>
                     @else
                         <li>
                             <a href="{{ route('dashboard') }}" class="nav-link">
@@ -83,7 +83,7 @@
                         <li>
                             <form method="POST" action="{{ route('logout') }}" style="display: inline;">
                                 @csrf
-                                <button type="submit" class="nav-link" style="background: none; border: none; cursor: pointer;">Logout</button>
+                                <button type="submit" class="nav-link" style="background: none; border: none; cursor: pointer;">Выход</button>
                             </form>
                         </li>
                     @endguest
@@ -158,7 +158,7 @@
         </div>
 
         <!-- Right Part: Login Form -->
-        <div class="login-block">
+        <div class="login-block" id="login-form">
             <div class="login-header">
                 <img src="{{ asset('images/apple-touch-icon.png') }}" alt="Icon">
                 <p>Присоединяйтесь к бизнес-сообществу</p>
@@ -202,7 +202,7 @@
                 <button type="submit" class="btn-login">Войти</button>
 
                 <div class="register-link">
-                    <a href="{{ route('register') }}">Create an account</a>
+                    <a href="{{ route('register') }}">Создать аккаунт</a>
                 </div>
             </form>
 


### PR DESCRIPTION
## Summary

- **#112**: валюта в виджете ставок — `₽` → динамический `currency_symbol`
- **#111**: цветные статусы тендеров в виджете дашборда (Приём заявок / Торги / Завершён и т.д.)
- **#110**: бейджи статусов приглашений — тип тендера, статус приглашения, статус тендера
- **#109**: вкладка «Ставки» аукциона скрыта до завершения (closed/cancelled)
- **#108**: адаптивность шапки страницы компании (мобильные устройства)
- **#105**: адаптивность карточек заявок на вступление в компанию
- **#107**: перевод welcome-страницы на русский + якорь на форму логина
- **#106**: редактирование валюты аукциона (select + динамический символ в label)
- **#115**: скрытие результатов завершённых тендеров — миграция `is_results_hidden`, чекбокс в формах, логика видимости (организатор + участники)

Closes #112, #111, #110, #109, #108, #105, #107, #106, #115

## NEWS

🔧 **Исправления и улучшения по обратной связи**

Большой пакет доработок: правильное отображение валют, цветные статусы тендеров и приглашений, адаптивная вёрстка для мобильных, перевод стартовой страницы. Новая возможность — скрытие результатов завершённых тендеров от посторонних (чекбокс при создании/редактировании).

## Test plan

- [ ] Проверить виджет ставок на дашборде — валюта отображается правильно
- [ ] Проверить виджет тендеров — цветные статусы
- [ ] Проверить виджет приглашений — три бейджа
- [ ] Открыть аукцион в статусе active — вкладка ставок скрыта
- [ ] Страница компании на мобильном — респонсивная шапка
- [ ] Welcome-страница — русский текст, кнопка «Войти» скроллит к форме
- [ ] Редактирование аукциона — select валюты работает
- [ ] Создать RFQ/аукцион с чекбоксом «Скрыть результаты» — после закрытия результаты видны только организатору и участникам
- [ ] Прогнать миграцию `is_results_hidden`

🤖 Generated with [Claude Code](https://claude.com/claude-code)