### PR TITLE
feat: форма регистрации на главной странице

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ composer run dev          # Start all: Laravel + Queue (queue:listen) + Logs (pa
 php artisan serve         # Start Laravel server only
 php artisan queue:work    # Process queue jobs (production)
 php artisan queue:listen  # Process queue jobs with auto-reload on code changes (dev)
+npm run dev               # Vite dev server with HMR (included in `composer run dev`)
+npm run build             # Production frontend build
 ```
 
 ### Testing
@@ -199,6 +201,7 @@ Welcome page uses gradient: `#28a745 → #81b407` (defined in `public/css/custom
 - **app** container (`my_project_app`): PHP 8.2-FPM + Nginx + Supervisor, timezone Europe/Moscow, resource limits: 1 CPU / 0.9G RAM. Port 80 not exposed by default (use nginx-proxy in production)
 - **db** container (`my_project_db`): PostgreSQL 14 Alpine, host port 5435, timezone Europe/Moscow
 - Production: `docker-compose.override.yml.prod` with nginx-proxy + Let's Encrypt
+- Upload limits: 100M (`docker/uploads.ini`), client_max_body_size 100M (`docker/nginx.conf`)
 
 ## Production Deployment
 
@@ -286,6 +289,8 @@ All project docs in `docs/`:
 - `claude/start_message.md` — Context for new Claude Code sessions
 
 Wiki docs in `wiki/` — detailed module documentation (architecture, models, services, deploy, frontend, etc.)
+
+**Note:** No CI/CD pipelines configured. Deployment is manual via SSH.
 
 ## Claude Code Instructions
 - После каждого успешного выполнения задачи записывай краткий отчет (что сделано, какие файлы изменены) в конец файла `docs/CHANGELOG_CLAUDE.md`.

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules;
 use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
@@ -41,10 +42,22 @@ class RegisteredUserController extends Controller
             $rules['g-recaptcha-response'] = ['required', 'string'];
         }
 
-        $request->validate($rules);
+        $validator = Validator::make($request->all(), $rules);
+
+        if ($validator->fails()) {
+            return redirect('/?mode=register')
+                ->withErrors($validator)
+                ->withInput();
+        }
 
         if ($request->has('g-recaptcha-response')) {
-            $this->verifyRecaptcha($request->input('g-recaptcha-response'));
+            try {
+                $this->verifyRecaptcha($request->input('g-recaptcha-response'));
+            } catch (ValidationException $e) {
+                return redirect('/?mode=register')
+                    ->withErrors($e->errors())
+                    ->withInput();
+            }
         }
 
         $user = User::create([

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -1187,3 +1187,15 @@ SESSION_SECURE_COOKIE=true
 **Решение:** Пересоздан Caddy-контейнер: `docker compose up -d --force-recreate caddy`. Теперь он корректно подключён к обеим сетям (`bizzio_app-network` + `docker_default`), как прописано в override.
 
 **Изменённые файлы:** нет (операция на сервере)
+
+---
+
+## 2026-03-18: Регистрация на главной странице
+
+**Что сделано:** Форма регистрации теперь отображается на главной странице (bizzio.ru/?mode=register) вместо отдельной страницы /register. При нажатии «Создать аккаунт» показывается форма с полями: имя, email, пароль, подтверждение пароля. Ссылка «Уже есть аккаунт? Войти» возвращает на форму входа. Ошибки валидации корректно редиректят обратно на форму регистрации. Также исправлен баг в тесте reCAPTCHA (не устанавливался config site_key).
+
+**Изменённые файлы:**
+- `resources/views/welcome.blade.php` — добавлена форма регистрации с переключением по `?mode=register`
+- `routes/auth.php` — GET `/register` теперь редиректит на `/?mode=register`
+- `app/Http/Controllers/Auth/RegisteredUserController.php` — ошибки валидации редиректят на `/?mode=register`
+- `tests/Feature/Auth/RegistrationTest.php` — обновлены тесты, добавлен тест формы на welcome page

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -18,6 +18,10 @@
     <!-- Custom CSS -->
     <link rel="stylesheet" href="{{ asset('css/custom.css') }}">
 
+    @if (request('mode') === 'register' && config('services.recaptcha.site_key'))
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    @endif
+
     <!-- Favicon – современный минимальный набор 2025–2026 -->
     <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('images/favicon-32x32.png') }}">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('images/favicon-16x16.png') }}">
@@ -73,7 +77,7 @@
                 <ul class="navbar-nav navbar-user">
                     @guest
                         <li><a href="#login-form" class="nav-link" onclick="document.getElementById('login-form').scrollIntoView({behavior:'smooth'});return false;">Войти</a></li>
-                        <li><a href="{{ route('register') }}" class="nav-link">Регистрация</a></li>
+                        <li><a href="{{ url('/?mode=register') }}" class="nav-link">Регистрация</a></li>
                     @else
                         <li>
                             <a href="{{ route('dashboard') }}" class="nav-link">
@@ -157,23 +161,86 @@
             </div>
         </div>
 
-        <!-- Right Part: Login Form -->
+        <!-- Right Part: Auth Form -->
+        @php $isRegister = request('mode') === 'register'; @endphp
         <div class="login-block" id="login-form">
             <div class="login-header">
                 <img src="{{ asset('images/apple-touch-icon.png') }}" alt="Icon">
-                <p>Присоединяйтесь к бизнес-сообществу</p>
+                <p>{{ $isRegister ? 'Создайте аккаунт' : 'Присоединяйтесь к бизнес-сообществу' }}</p>
             </div>
 
-            <!-- Login Form -->
-            <form action="{{ route('login') }}" method="POST">
+            @if ($isRegister)
+            <!-- Register Form -->
+            <form action="{{ url('/register') }}" method="POST">
                 @csrf
-                
+
                 <div class="form-group">
                     <div class="input-wrapper">
                         <span class="icon">
                             <i class="uil-user"></i>
                         </span>
-                        <input type="text" name="email" class="form-control" required placeholder="Email">
+                        <input type="text" name="name" class="form-control" required placeholder="Имя" value="{{ old('name') }}">
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="input-wrapper">
+                        <span class="icon">
+                            <i class="uil-envelope"></i>
+                        </span>
+                        <input type="email" name="email" class="form-control" required placeholder="Email" value="{{ old('email') }}">
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="input-wrapper">
+                        <span class="icon">
+                            <i class="uil-lock-alt"></i>
+                        </span>
+                        <input type="password" name="password" class="form-control" required placeholder="Пароль (мин. 8 символов)">
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="input-wrapper">
+                        <span class="icon">
+                            <i class="uil-lock"></i>
+                        </span>
+                        <input type="password" name="password_confirmation" class="form-control" required placeholder="Подтверждение пароля">
+                    </div>
+                </div>
+
+                @if (config('services.recaptcha.site_key'))
+                <div class="form-group" style="display: flex; justify-content: center; margin-bottom: 15px;">
+                    <div class="g-recaptcha" data-sitekey="{{ config('services.recaptcha.site_key') }}"></div>
+                </div>
+                @endif
+
+                @if ($errors->any())
+                    <div style="background: #ffe6e6; padding: 12px; border-radius: 8px; margin-bottom: 20px; color: #d32f2f; font-size: 0.9rem;">
+                        @foreach ($errors->all() as $error)
+                            <div>{{ $error }}</div>
+                        @endforeach
+                    </div>
+                @endif
+
+                <button type="submit" class="btn-login">Зарегистрироваться</button>
+
+                <div class="register-link">
+                    <a href="{{ url('/') }}">Уже есть аккаунт? Войти</a>
+                </div>
+            </form>
+            @else
+            <!-- Login Form -->
+            <form action="{{ route('login') }}" method="POST">
+                @csrf
+
+                <div class="form-group">
+                    <div class="input-wrapper">
+                        <span class="icon">
+                            <i class="uil-user"></i>
+                        </span>
+                        <input type="text" name="email" class="form-control" required placeholder="Email" value="{{ old('email') }}">
                     </div>
                 </div>
 
@@ -202,13 +269,14 @@
                 <button type="submit" class="btn-login">Войти</button>
 
                 <div class="register-link">
-                    <a href="{{ route('register') }}">Создать аккаунт</a>
+                    <a href="{{ url('/?mode=register') }}">Создать аккаунт</a>
                 </div>
             </form>
+            @endif
 
             <!-- OAuth Buttons -->
             <div class="oauth-divider">
-                <span>или войти через</span>
+                <span>или {{ $isRegister ? 'зарегистрироваться' : 'войти' }} через</span>
             </div>
 
             <div class="oauth-buttons">

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -12,7 +12,7 @@ use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
-    Route::get('register', [RegisteredUserController::class, 'create'])
+    Route::get('register', fn () => redirect('/?mode=register'))
         ->name('register');
 
     Route::post('register', [RegisteredUserController::class, 'store']);

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -28,7 +28,16 @@ class RegistrationTest extends TestCase
     {
         $response = $this->get('/register');
 
+        $response->assertRedirect('/?mode=register');
+    }
+
+    public function test_registration_form_displayed_on_welcome_page(): void
+    {
+        $response = $this->get('/?mode=register');
+
         $response->assertStatus(200);
+        $response->assertSee('Зарегистрироваться');
+        $response->assertSee('Уже есть аккаунт?');
     }
 
     public function test_new_users_can_register(): void
@@ -50,6 +59,7 @@ class RegistrationTest extends TestCase
 
     public function test_registration_fails_without_captcha(): void
     {
+        config(['services.recaptcha.site_key' => 'test-site-key']);
         config(['services.recaptcha.secret_key' => 'test-secret']);
 
         $response = $this->post('/register', [
@@ -59,12 +69,14 @@ class RegistrationTest extends TestCase
             'password_confirmation' => 'password1A',
         ]);
 
+        $response->assertRedirect('/?mode=register');
         $response->assertSessionHasErrors('g-recaptcha-response');
         $this->assertGuest();
     }
 
     public function test_registration_fails_with_invalid_captcha(): void
     {
+        config(['services.recaptcha.site_key' => 'test-site-key']);
         config(['services.recaptcha.secret_key' => 'test-secret']);
         $this->fakeRecaptchaFailure();
 
@@ -76,6 +88,7 @@ class RegistrationTest extends TestCase
             'g-recaptcha-response' => 'invalid-token',
         ]);
 
+        $response->assertRedirect('/?mode=register');
         $response->assertSessionHasErrors('g-recaptcha-response');
         $this->assertGuest();
     }
@@ -108,6 +121,7 @@ class RegistrationTest extends TestCase
             'g-recaptcha-response' => 'any-token',
         ]);
 
+        $response->assertRedirect('/?mode=register');
         $response->assertSessionHasErrors('name');
         $this->assertGuest();
     }
@@ -124,6 +138,7 @@ class RegistrationTest extends TestCase
             'g-recaptcha-response' => 'any-token',
         ]);
 
+        $response->assertRedirect('/?mode=register');
         $response->assertSessionHasErrors('password');
         $this->assertGuest();
     }


### PR DESCRIPTION
## Summary

- Форма регистрации теперь отображается на главной странице (`/?mode=register`) вместо отдельной страницы `/register`
- `/register` редиректит на `/?mode=register` — пользователь остаётся на landing page
- Поля: Имя, Email, Пароль, Подтверждение пароля + reCAPTCHA + OAuth (Google, Яндекс)
- Ошибки валидации корректно возвращают на форму регистрации с сохранением введённых данных
- Ссылка «Уже есть аккаунт? Войти» возвращает на форму входа
- Исправлен баг в тесте reCAPTCHA (не устанавливался `services.recaptcha.site_key`)

Relates to #107

## Test plan

- [ ] Открыть bizzio.ru — видна форма входа
- [ ] Нажать «Создать аккаунт» — форма меняется на регистрацию (URL: `/?mode=register`)
- [ ] Нажать «Уже есть аккаунт? Войти» — возврат к форме входа
- [ ] Зарегистрировать нового пользователя — редирект на dashboard
- [ ] Ввести невалидные данные — ошибки показываются на форме регистрации
- [ ] Проверить OAuth-кнопки на обеих формах
- [ ] Проверить мобильную версию

🤖 Generated with [Claude Code](https://claude.com/claude-code)