### PR TITLE
fix: пакет доработок по замечаниям заказчика (10 issues)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,9 @@ Test env: `QUEUE_CONNECTION=sync` (jobs run synchronously unless `Queue::fake()`
 ./vendor/bin/pint --test     # Check code style (Laravel Pint)
 ./vendor/bin/pint            # Fix code style
 ```
+- All PHP files use `declare(strict_types=1);`
+- Full type hints on properties, parameters, and return types
+- PSR-12 + Laravel conventions
 
 ### Database & Cache
 ```bash
@@ -211,6 +214,7 @@ Supervisor (configured in `docker/supervisord.conf`) auto-starts: php-fpm, nginx
 # Deploy
 git pull origin main
 docker compose exec app composer install --no-dev --optimize-autoloader
+docker compose exec app npm run build                    # Rebuild frontend assets (Vite)
 docker compose exec app php artisan migrate --force
 docker compose exec app php artisan config:cache && docker compose exec app php artisan route:cache && docker compose exec app php artisan view:cache
 docker compose exec app php artisan queue:restart

--- a/app/Http/Controllers/AuctionController.php
+++ b/app/Http/Controllers/AuctionController.php
@@ -23,16 +23,26 @@ class AuctionController extends Controller
     {
         $query = Auction::with(['company.industry', 'creator', 'bids']);
 
-        // Скрываем черновики от посторонних (C3)
-        // Черновики видны только модераторам компании-организатора
+        // Скрываем черновики от посторонних (C3) и закрытые аукционы от неприглашённых (#38)
         if (auth()->check()) {
             $userCompanies = auth()->user()->moderatedCompanies()->pluck('companies.id');
             $query->where(function ($q) use ($userCompanies) {
-                $q->where('status', '!=', 'draft')
-                  ->orWhereIn('company_id', $userCompanies);
+                $q->where(function ($inner) use ($userCompanies) {
+                    // Черновики — только свои
+                    $inner->where('status', '!=', 'draft')
+                          ->orWhereIn('company_id', $userCompanies);
+                })->where(function ($inner) use ($userCompanies) {
+                    // #38: Закрытые аукционы — только организатор или приглашённые
+                    $inner->where('type', '!=', 'closed')
+                          ->orWhereIn('company_id', $userCompanies)
+                          ->orWhereHas('invitations', function ($inv) use ($userCompanies) {
+                              $inv->whereIn('company_id', $userCompanies);
+                          });
+                });
             });
         } else {
-            $query->where('status', '!=', 'draft');
+            $query->where('status', '!=', 'draft')
+                  ->where('type', '!=', 'closed');
         }
 
         if ($request->filled('search')) {
@@ -332,6 +342,14 @@ public function storeBid(StoreAuctionBidRequest $request, Auction $auction)
             'status' => 'pending',
         ]);
         
+        // #110: При подаче заявки (initial bid) обновляем статус приглашения на accepted
+        if ($isInitialBid) {
+            $auction->invitations()
+                ->where('company_id', $companyId)
+                ->where('status', 'pending')
+                ->update(['status' => 'accepted']);
+        }
+
         // Обновление времени последней ставки (для торгов)
         if (!$isInitialBid) {
             $auction->update(['last_bid_at' => Carbon::now()]);

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -160,7 +160,7 @@ class DashboardController extends Controller
                 'url' => route('auctions.show', $a),
                 'created_at' => $a->created_at,
             ];
-        }))->sortByDesc('created_at')->take(5)->values();
+        }))->sortByDesc('created_at')->take(3)->values();
 
         $rfqInvitations = RfqInvitation::whereIn('company_id', $companyIds)
             ->with('rfq')
@@ -210,7 +210,7 @@ class DashboardController extends Controller
                 'url' => route('auctions.show', $i->auction_id),
                 'created_at' => $i->created_at,
             ];
-        }))->sortByDesc('created_at')->take(5)->values();
+        }))->sortByDesc('created_at')->take(3)->values();
 
         $rfqBids = RfqBid::whereIn('company_id', $companyIds)
             ->with('rfq')
@@ -241,7 +241,7 @@ class DashboardController extends Controller
             'currency_symbol' => $b->auction->currency_symbol ?? '₽',
             'url' => route('auctions.show', $b->auction_id),
             'created_at' => $b->created_at,
-        ]))->sortByDesc('created_at')->take(5)->values();
+        ]))->sortByDesc('created_at')->take(3)->values();
 
         return view('dashboard', compact(
             'userCompanies',

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -123,7 +123,17 @@ class ProjectController extends Controller
     {
         $project->load(['company', 'creator', 'participants', 'members', 'comments.user']);
 
-        return view('projects.show', compact('project'));
+        // #73: Определяем, может ли пользователь комментировать (участник проекта или сотрудник компании-участника)
+        $canComment = false;
+        if (auth()->check()) {
+            $user = auth()->user();
+            $canComment = $project->isMember($user)
+                || $project->participants()
+                    ->whereIn('companies.id', $user->companies()->pluck('companies.id'))
+                    ->exists();
+        }
+
+        return view('projects.show', compact('project', 'canComment'));
     }
 
     /**
@@ -226,6 +236,17 @@ class ProjectController extends Controller
      */
     public function storeComment(Request $request, Project $project)
     {
+        // #73: Комментировать могут только участники проекта (member или сотрудник компании-участника)
+        $user = auth()->user();
+        $isMember = $project->isMember($user);
+        $isCompanyParticipant = $project->participants()
+            ->whereIn('companies.id', $user->companies()->pluck('companies.id'))
+            ->exists();
+
+        if (!$isMember && !$isCompanyParticipant) {
+            abort(403, 'Комментировать могут только участники проекта.');
+        }
+
         $request->validate([
             'body' => 'required|string|max:5000',
             'parent_id' => 'nullable|exists:project_comments,id',

--- a/app/Http/Controllers/TenderController.php
+++ b/app/Http/Controllers/TenderController.php
@@ -44,6 +44,7 @@ class TenderController extends Controller
                 ->orderBy('created_at', 'desc');
 
             $this->applyDraftFilter($auctionQuery);
+            $this->applyClosedAuctionFilter($auctionQuery);
             $this->applyFilters($auctionQuery, $request);
 
             $auctions = $auctionQuery->get()->map(fn($a) => [
@@ -181,6 +182,25 @@ class TenderController extends Controller
             });
         } else {
             $query->where('status', '!=', 'draft');
+        }
+    }
+
+    /**
+     * #38: Закрытые аукционы видны только организатору и приглашённым
+     */
+    private function applyClosedAuctionFilter($query): void
+    {
+        if (auth()->check()) {
+            $userCompanies = auth()->user()->moderatedCompanies()->pluck('companies.id');
+            $query->where(function ($q) use ($userCompanies) {
+                $q->where('type', '!=', 'closed')
+                  ->orWhereIn('company_id', $userCompanies)
+                  ->orWhereHas('invitations', function ($inv) use ($userCompanies) {
+                      $inv->whereIn('company_id', $userCompanies);
+                  });
+            });
+        } else {
+            $query->where('type', '!=', 'closed');
         }
     }
 

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -4,6 +4,45 @@
 
 ---
 
+## 2026-03-25 — Пакет доработок по замечаниям заказчика (10 issues)
+
+**Контекст:** Заказчик (@MSverlov) 23 марта прокомментировал 10+ issues с замечаниями к реализованному функционалу. Все задачи из столбца "Правки после тестов" канбана.
+
+### Исправления:
+
+1. **#110 — Статус приглашения в аукцион** — при подаче initial bid статус приглашения обновляется на `accepted`.
+   - `app/Http/Controllers/AuctionController.php` — добавлено обновление `AuctionInvitation.status` в `storeBid()`
+
+2. **#107 — Лишние ссылки Login/Register на welcome** — убраны ссылки "Войти" и "Регистрация" из правого верхнего угла.
+   - `resources/views/welcome.blade.php` — удалена секция `@guest` в navbar-user
+
+3. **#111 — Dashboard виджеты: лимит 3 записи** — в каждом блоке оставлено 3 записи (было 5).
+   - `app/Http/Controllers/DashboardController.php` — `take(5)` → `take(3)` для myTenders, myInvitations, myBids
+
+4. **#60 — Dashboard мобильная: порядок блоков** — на мобильном блоки закупок теперь перед Лентой.
+   - `resources/views/dashboard.blade.php` — добавлены Tailwind `order-*` классы для мобильной перестановки
+
+5. **#73 — Комментарии проектов только для участников** — неавторизованные пользователи больше не могут комментировать.
+   - `app/Http/Controllers/ProjectController.php` — добавлена проверка `isMember` / `isCompanyParticipant` в `storeComment()` и `show()`
+   - `resources/views/projects/show.blade.php` — форма скрыта для не-участников
+
+6. **#59 — Колокольчик уведомлений на мобильном** — добавлена иконка колокольчика рядом с гамбургером + пункт "Уведомления" в мобильном меню.
+   - `resources/views/layouts/navigation.blade.php` — мобильный bell icon + responsive-nav-link
+
+7. **#71 + #72 — Управление участниками компании** — во вкладке "Люди" добавлен inline-поиск пользователей, dropdown смены роли и кнопка удаления (по аналогии с проектами).
+   - `resources/views/companies/show.blade.php` — переписана вкладка "Люди" с формой поиска и inline-управлением
+
+8. **#69 — "Обратная связь" в меню аккаунта** — добавлен пункт в desktop dropdown и mobile menu.
+   - `resources/views/layouts/navigation.blade.php` — новый `<x-dropdown-link>` и `<x-responsive-nav-link>`
+   - `resources/views/profile/partials/feedback-form.blade.php` — добавлен якорь `#feedback`
+
+9. **#38 — Закрытые аукционы только для приглашённых** — закрытые аукционы скрыты из общего каталога для неприглашённых. Имена обезличены.
+   - `app/Http/Controllers/AuctionController.php` — фильтр `type=closed` в `index()`
+   - `app/Http/Controllers/TenderController.php` — новый метод `applyClosedAuctionFilter()`
+   - `resources/views/auctions/show.blade.php` — обезличивание имён участников и приглашённых для не-организаторов
+
+---
+
 ## 2026-03-23 — Оптимизация производительности: Tailwind CDN → Vite build
 
 **Проблема:** Страницы «Закупки» и «Новости» грузились очень медленно.

--- a/resources/views/auctions/show.blade.php
+++ b/resources/views/auctions/show.blade.php
@@ -756,8 +756,13 @@
                                             @else
                                                 {{-- Для статуса active (приём заявок) или closed (завершён) --}}
                                                 <td class="px-6 py-4 whitespace-nowrap">
-                                                    @if($auction->status === 'closed')
-                                                        {{-- После закрытия показываем названия компаний --}}
+                                                    @if($auction->status === 'closed' && $auction->type !== 'closed')
+                                                        {{-- После закрытия открытого аукциона показываем названия компаний --}}
+                                                        <a href="{{ route('companies.show', $bid->company) }}" class="text-sm font-medium text-emerald-600 hover:text-emerald-500">
+                                                            {{ $bid->company->name }}
+                                                        </a>
+                                                    @elseif($auction->status === 'closed' && $auction->type === 'closed' && $auction->canManage(auth()->user()))
+                                                        {{-- #38: В закрытом аукционе после завершения — имена видны только организатору --}}
                                                         <a href="{{ route('companies.show', $bid->company) }}" class="text-sm font-medium text-emerald-600 hover:text-emerald-500">
                                                             {{ $bid->company->name }}
                                                         </a>
@@ -802,22 +807,31 @@
                                 @foreach($auction->invitations as $invitation)
                                     <div class="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
                                         <div class="flex items-center">
-                                            @if($invitation->company->logo)
-                                                <img src="{{ asset('storage/' . $invitation->company->logo) }}" 
-                                                     alt="{{ $invitation->company->name }}" 
+                                            @php
+                                                $isManager = auth()->check() && $auction->canManage(auth()->user());
+                                                $isOwnCompany = auth()->check() && auth()->user()->moderatedCompanies()->pluck('companies.id')->contains($invitation->company_id);
+                                                $showName = $isManager || $isOwnCompany;
+                                            @endphp
+                                            @if($showName && $invitation->company->logo)
+                                                <img src="{{ asset('storage/' . $invitation->company->logo) }}"
+                                                     alt="{{ $invitation->company->name }}"
                                                      class="w-12 h-12 rounded-full mr-3 object-cover">
                                             @else
                                                 <div class="w-12 h-12 rounded-full mr-3 bg-gray-200 flex items-center justify-center">
                                                     <span class="text-sm text-gray-500 font-semibold">
-                                                        {{ strtoupper(substr($invitation->company->name, 0, 2)) }}
+                                                        {{ $showName ? strtoupper(substr($invitation->company->name, 0, 2)) : $loop->iteration }}
                                                     </span>
                                                 </div>
                                             @endif
                                             <div>
-                                                <a href="{{ route('companies.show', $invitation->company) }}" 
-                                                   class="text-sm font-medium text-emerald-600 hover:text-emerald-500">
-                                                    {{ $invitation->company->name }}
-                                                </a>
+                                                @if($showName)
+                                                    <a href="{{ route('companies.show', $invitation->company) }}"
+                                                       class="text-sm font-medium text-emerald-600 hover:text-emerald-500">
+                                                        {{ $invitation->company->name }}
+                                                    </a>
+                                                @else
+                                                    <span class="text-sm font-medium text-gray-900">Участник {{ $loop->iteration }}</span>
+                                                @endif
                                                 <p class="text-xs text-gray-500">
                                                     Приглашён: {{ $invitation->created_at->format('d.m.Y H:i') }}
                                                 </p>

--- a/resources/views/companies/show.blade.php
+++ b/resources/views/companies/show.blade.php
@@ -323,34 +323,138 @@
 
                 <!-- Вкладка: Люди -->
                 <div id="content-people" class="tab-content hidden">
+                    @php
+                        $canManagePeople = auth()->check() && $company->canManageModerators(auth()->user());
+                        $roleLabels = ['owner' => 'Владелец', 'admin' => 'Админ', 'moderator' => 'Модератор', 'member' => 'Участник'];
+                        $roleBadgeColors = [
+                            'owner' => 'bg-green-100 text-green-800',
+                            'admin' => 'bg-red-100 text-red-800',
+                            'moderator' => 'bg-blue-100 text-blue-800',
+                            'member' => 'bg-gray-100 text-gray-800',
+                        ];
+                        $editableRoles = ['admin' => 'Админ', 'moderator' => 'Модератор', 'member' => 'Участник'];
+                    @endphp
+
+                    {{-- #71: Форма добавления участника (по аналогии с проектами) --}}
+                    @if($canManagePeople)
+                        <div class="mb-6 p-4 bg-gray-50 rounded-lg" x-data="companyUserSearch()">
+                            <h4 class="text-sm font-semibold text-gray-700 mb-3">Добавить участника</h4>
+                            <form method="POST" action="{{ route('companies.moderators.store', $company) }}">
+                                @csrf
+                                <input type="hidden" name="user_id" x-model="selectedUserId">
+                                <div class="flex flex-col sm:flex-row gap-3">
+                                    <div class="flex-1 relative">
+                                        <template x-if="!selectedUserId">
+                                            <div>
+                                                <input type="text"
+                                                       x-model="query"
+                                                       @input.debounce.300ms="search()"
+                                                       @focus="if(query.length >= 2) showResults = true"
+                                                       @click.away="showResults = false"
+                                                       placeholder="Поиск пользователя по имени или email..."
+                                                       class="w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm">
+                                                <div x-show="showResults" x-cloak
+                                                     class="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-md shadow-lg max-h-48 overflow-y-auto">
+                                                    <template x-if="loading">
+                                                        <div class="p-3 text-center text-gray-500 text-sm">Поиск...</div>
+                                                    </template>
+                                                    <template x-if="!loading && results.length === 0 && query.length >= 2">
+                                                        <div class="p-3 text-center text-gray-500 text-sm">Пользователи не найдены</div>
+                                                    </template>
+                                                    <template x-for="user in results" :key="user.id">
+                                                        <button type="button" @click="selectUser(user)"
+                                                                class="w-full text-left px-3 py-2 hover:bg-gray-50 border-b border-gray-100 last:border-0">
+                                                            <div class="text-sm font-medium text-gray-900" x-text="user.title"></div>
+                                                            <div class="text-xs text-gray-500" x-text="user.subtitle"></div>
+                                                        </button>
+                                                    </template>
+                                                </div>
+                                            </div>
+                                        </template>
+                                        <template x-if="selectedUserId">
+                                            <div class="flex items-center gap-2 p-2 bg-white border border-gray-300 rounded-md">
+                                                <span class="text-sm text-gray-900 flex-1" x-text="selectedUserName"></span>
+                                                <button type="button" @click="clearSelection()" class="text-gray-400 hover:text-red-500">
+                                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                                    </svg>
+                                                </button>
+                                            </div>
+                                        </template>
+                                    </div>
+                                    <div>
+                                        <select name="role" class="rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm">
+                                            @foreach($editableRoles as $value => $label)
+                                                <option value="{{ $value }}" {{ $value === 'member' ? 'selected' : '' }}>{{ $label }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                    <div>
+                                        <button type="submit" :disabled="!selectedUserId"
+                                                class="inline-flex items-center px-4 py-2 bg-emerald-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-emerald-700 transition disabled:opacity-50 disabled:cursor-not-allowed">
+                                            Добавить
+                                        </button>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+                    @endif
+
+                    {{-- Список участников с inline-управлением (#71 + #72) --}}
                     @if($company->moderators->count() > 0)
                         <div class="space-y-3">
                             @foreach($company->moderators as $moderator)
-                                <div class="flex items-center p-4 bg-gray-50 rounded-lg">
-                                    <div class="w-12 h-12 rounded-full bg-emerald-100 flex items-center justify-center mr-4">
-                                        <span class="text-base font-semibold text-emerald-600">
-                                            {{ strtoupper(substr($moderator->name, 0, 2)) }}
+                                <div class="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
+                                    <div class="flex items-center gap-3">
+                                        <div class="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center">
+                                            <span class="text-sm font-semibold text-emerald-700">
+                                                {{ strtoupper(mb_substr($moderator->name, 0, 1)) }}
+                                            </span>
+                                        </div>
+                                        <div>
+                                            <div class="text-sm font-medium text-gray-900">{{ $moderator->name }}</div>
+                                            <div class="text-xs text-gray-500">{{ $moderator->email }}</div>
+                                        </div>
+                                        @php $role = $moderator->pivot->role ?? 'member'; @endphp
+                                        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium {{ $roleBadgeColors[$role] ?? 'bg-gray-100 text-gray-800' }}">
+                                            {{ $roleLabels[$role] ?? $role }}
                                         </span>
-                                    </div>
-                                    <div class="flex-1">
-                                        <p class="text-sm font-semibold text-gray-900">{{ $moderator->name }}</p>
-                                        <p class="text-xs text-gray-500">{{ $moderator->email }}</p>
-                                        @if($moderator->pivot->role)
-                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-emerald-100 text-emerald-800 mt-1">
-                                                {{ $moderator->pivot->role }}
+                                        @if($company->created_by === $moderator->id)
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
+                                                Создатель
                                             </span>
                                         @endif
                                     </div>
-                                    @if($company->created_by === $moderator->id)
-                                        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
-                                            Создатель
-                                        </span>
+
+                                    {{-- #72: Inline управление ролями (для менеджеров, кроме создателя) --}}
+                                    @if($canManagePeople && $moderator->id !== $company->created_by)
+                                        <div class="flex items-center gap-2">
+                                            <form method="POST" action="{{ route('companies.moderators.update', [$company, $moderator]) }}" class="inline">
+                                                @csrf
+                                                @method('PUT')
+                                                <select name="role" onchange="this.form.submit()" class="text-xs rounded border-gray-300 py-1">
+                                                    @foreach($editableRoles as $value => $label)
+                                                        <option value="{{ $value }}" {{ $role === $value ? 'selected' : '' }}>{{ $label }}</option>
+                                                    @endforeach
+                                                </select>
+                                            </form>
+                                            <form method="POST" action="{{ route('companies.moderators.destroy', [$company, $moderator]) }}"
+                                                  onsubmit="return confirm('Удалить пользователя {{ $moderator->name }} из компании?')">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="text-red-400 hover:text-red-600" title="Удалить из компании">
+                                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+                                                    </svg>
+                                                </button>
+                                            </form>
+                                        </div>
                                     @endif
                                 </div>
                             @endforeach
                         </div>
                     @else
-                        <p class="text-gray-500 text-center py-8">Модераторы не назначены</p>
+                        <p class="text-gray-500 text-center py-8">Участники не назначены</p>
                     @endif
 
                     {{-- C6: Запросы на присоединение (перенесены из «Управление» во «Люди») --}}
@@ -848,6 +952,58 @@ function closeEditModal() {
 // C5: Alpine.js компонент поиска пользователей
 function userSearch() {
     const companyId = {{ $company->id }};
+    const moderatorIds = @json($company->moderators->pluck('id'));
+
+    return {
+        query: '',
+        results: [],
+        showResults: false,
+        loading: false,
+        selectedUserId: '',
+        selectedUserName: '',
+
+        async search() {
+            if (this.query.length < 2) {
+                this.results = [];
+                this.showResults = false;
+                return;
+            }
+
+            this.loading = true;
+            this.showResults = true;
+
+            try {
+                const response = await fetch(`/search/quick?q=${encodeURIComponent(this.query)}`);
+                const data = await response.json();
+
+                this.results = data
+                    .filter(item => item.type === 'user')
+                    .filter(item => !moderatorIds.includes(item.id));
+            } catch (e) {
+                this.results = [];
+            } finally {
+                this.loading = false;
+            }
+        },
+
+        selectUser(user) {
+            this.selectedUserId = user.id;
+            this.selectedUserName = user.title + (user.subtitle ? ' (' + user.subtitle + ')' : '');
+            this.query = '';
+            this.results = [];
+            this.showResults = false;
+        },
+
+        clearSelection() {
+            this.selectedUserId = '';
+            this.selectedUserName = '';
+            this.query = '';
+        }
+    };
+}
+
+// #71: Alpine.js компонент поиска пользователей (для вкладки Люди)
+function companyUserSearch() {
     const moderatorIds = @json($company->moderators->pluck('id'));
 
     return {

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -10,26 +10,26 @@
             <div class="grid grid-cols-1 lg:grid-cols-5 gap-6">
 
                 {{-- Левая колонка --}}
-                <div class="lg:col-span-1 space-y-4">
+                <div class="lg:col-span-1 space-y-4 order-1 lg:order-1">
                     @include('partials.dashboard.profile-card')
                     @include('partials.dashboard.join-requests-widget')
                     @include('partials.dashboard.my-companies-widget')
                     @include('partials.dashboard.my-projects-widget')
                 </div>
 
+                {{-- Правая колонка (на мобильном — перед Лентой) --}}
+                <div class="lg:col-span-1 space-y-4 order-2 lg:order-3">
+                    @include('partials.dashboard.tenders-widget')
+                    @include('partials.dashboard.invitations-widget')
+                    @include('partials.dashboard.bids-widget')
+                </div>
+
                 {{-- Центральная колонка --}}
-                <div class="lg:col-span-3 space-y-6">
+                <div class="lg:col-span-3 space-y-6 order-3 lg:order-2">
                     @include('partials.dashboard.news-widget')
                     @include('partials.dashboard.post-form')
                     @include('partials.dashboard.posts-feed')
                     @include('partials.dashboard.activity-feed')
-                </div>
-
-                {{-- Правая колонка --}}
-                <div class="lg:col-span-1 space-y-4">
-                    @include('partials.dashboard.tenders-widget')
-                    @include('partials.dashboard.invitations-widget')
-                    @include('partials.dashboard.bids-widget')
                 </div>
 
             </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -263,6 +263,10 @@
                                 {{ __('Лента активности') }}
                             </x-dropdown-link>
 
+                            <x-dropdown-link :href="route('profile.edit') . '#feedback'">
+                                {{ __('Обратная связь') }}
+                            </x-dropdown-link>
+
                             <!-- Authentication -->
                             <form method="POST" action="{{ route('logout') }}">
                                 @csrf
@@ -286,8 +290,19 @@
                 @endauth
             </div>
 
-            <!-- Hamburger -->
+            <!-- Hamburger + Mobile Bell -->
             <div class="-me-2 flex items-center sm:hidden">
+                @auth
+                    <a href="{{ route('notifications.index') }}" class="relative p-2 text-gray-400 hover:text-gray-500">
+                        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path>
+                        </svg>
+                        @php $mobileBellCount = auth()->user()->unreadNotifications()->count(); @endphp
+                        @if($mobileBellCount > 0)
+                            <span class="absolute top-0.5 right-0.5 inline-flex items-center justify-center px-1.5 py-0.5 text-xs font-bold leading-none text-white bg-red-500 rounded-full">{{ $mobileBellCount > 99 ? '99+' : $mobileBellCount }}</span>
+                        @endif
+                    </a>
+                @endauth
                 <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
                     <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
                         <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
@@ -390,6 +405,18 @@
 
                     <x-responsive-nav-link :href="route('dashboard')">
                         {{ __('Лента активности') }}
+                    </x-responsive-nav-link>
+
+                    <x-responsive-nav-link :href="route('notifications.index')">
+                        {{ __('Уведомления') }}
+                        @php $mobileUnread = auth()->user()->unreadNotifications()->count(); @endphp
+                        @if($mobileUnread > 0)
+                            <span class="ml-2 inline-flex items-center justify-center px-2 py-0.5 text-xs font-bold leading-none text-white bg-red-500 rounded-full">{{ $mobileUnread > 99 ? '99+' : $mobileUnread }}</span>
+                        @endif
+                    </x-responsive-nav-link>
+
+                    <x-responsive-nav-link :href="route('profile.edit') . '#feedback'">
+                        {{ __('Обратная связь') }}
                     </x-responsive-nav-link>
 
                     <!-- Authentication -->

--- a/resources/views/profile/partials/feedback-form.blade.php
+++ b/resources/views/profile/partials/feedback-form.blade.php
@@ -1,4 +1,4 @@
-<section>
+<section id="feedback">
     <header>
         <h2 class="text-lg font-medium text-gray-900">
             Обратная связь

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -215,7 +215,7 @@
 
                 <!-- Вкладка: Комментарии -->
                 <div id="content-comments" class="tab-content hidden">
-                    @auth
+                    @if($canComment ?? false)
                         <!-- Форма добавления комментария -->
                         <form method="POST" 
                               action="{{ route('projects.comments.store', $project->slug) }}" 
@@ -240,16 +240,20 @@
                                 </button>
                             </div>
                         </form>
-                    @else
+                    @elseif(!auth()->check())
                         <div class="bg-gray-50 rounded-lg p-4 mb-6 text-center">
                             <p class="text-gray-600">
-                                <a href="{{ route('login') }}" class="text-emerald-600 hover:text-emerald-500 font-semibold">Войдите</a> 
-                                или 
-                                <a href="{{ route('register') }}" class="text-emerald-600 hover:text-emerald-500 font-semibold">зарегистрируйтесь</a>, 
+                                <a href="{{ route('login') }}" class="text-emerald-600 hover:text-emerald-500 font-semibold">Войдите</a>
+                                или
+                                <a href="{{ route('register') }}" class="text-emerald-600 hover:text-emerald-500 font-semibold">зарегистрируйтесь</a>,
                                 чтобы оставить комментарий
                             </p>
                         </div>
-                    @endauth
+                    @else
+                        <div class="bg-gray-50 rounded-lg p-4 mb-6 text-center">
+                            <p class="text-gray-500 text-sm">Комментировать могут только участники проекта.</p>
+                        </div>
+                    @endif
 
                     <!-- Список комментариев -->
                     <div id="comments-list" class="space-y-4">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -75,10 +75,7 @@
 
                 <!-- User Navigation -->
                 <ul class="navbar-nav navbar-user">
-                    @guest
-                        <li><a href="#login-form" class="nav-link" onclick="document.getElementById('login-form').scrollIntoView({behavior:'smooth'});return false;">Войти</a></li>
-                        <li><a href="{{ url('/?mode=register') }}" class="nav-link">Регистрация</a></li>
-                    @else
+                    @auth
                         <li>
                             <a href="{{ route('dashboard') }}" class="nav-link">
                                 {{ Auth::user()->name }}
@@ -90,7 +87,7 @@
                                 <button type="submit" class="nav-link" style="background: none; border: none; cursor: pointer;">Выход</button>
                             </form>
                         </li>
-                    @endguest
+                    @endauth
                 </ul>
             </nav>
         </header>


### PR DESCRIPTION
## Summary

Пакет исправлений по замечаниям @MSverlov от 23.03.2026 (столбец «Правки после тестов» канбана):

- **#110** — Статус приглашения в аукцион обновляется на `accepted` при подаче заявки
- **#107** — Убраны лишние ссылки Login/Register из хедера welcome-страницы
- **#111** — Dashboard виджеты ограничены 3 записями + ссылка «Все»
- **#60** — На мобильном блоки закупок/заявок/приглашений перед Лентой
- **#73** — Комментарии к проектам только для участников (member или сотрудник компании-участника)
- **#59** — Колокольчик уведомлений на мобильном (иконка + пункт меню + бейдж)
- **#71/#72** — Управление участниками компании с inline-поиском и сменой ролей (по аналогии с проектами)
- **#69** — Ссылка «Обратная связь» в desktop dropdown и мобильном меню
- **#38** — Закрытые аукционы скрыты из каталога для неприглашённых, имена обезличены

Closes #38, Closes #59, Closes #60, Closes #69, Closes #71, Closes #72, Closes #73, Closes #107, Closes #110, Closes #111

## Test plan

- [ ] Создать закрытый аукцион — убедиться что он не виден неприглашённым в каталоге
- [ ] Подать заявку на закрытый аукцион — проверить что статус приглашения стал «Принято»
- [ ] Проверить welcome-страницу — нет ссылок Login/Register в хедере
- [ ] Проверить dashboard — в каждом виджете максимум 3 записи
- [ ] Проверить dashboard на мобильном — блоки закупок перед Лентой
- [ ] Оставить комментарий к проекту от неучастника — должно быть 403
- [ ] Проверить колокольчик на мобильном — должен быть рядом с гамбургером
- [ ] Проверить меню аккаунта — пункт «Обратная связь» присутствует
- [ ] На странице компании вкладка «Люди» — есть поиск + inline-смена ролей

🤖 Generated with [Claude Code](https://claude.com/claude-code)