### PR TITLE
feat: доработки Друзья (#126) + поиск в шапке (#130)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,8 @@ Events registered in `AppServiceProvider@registerEventListeners()`:
 - `ProjectJoinRequestCreated` → `SendProjectJoinRequestNotification`
 - `ProjectJoinRequestReviewed` → `SendProjectJoinRequestReviewedNotification`
 - `UserSubscribed` → `SendUserSubscribedNotification`
+- `FriendRequestSent` → `SendFriendRequestNotification`
+- `FriendRequestAccepted` → `SendFriendRequestAcceptedNotification`
 
 ### Key Packages
 - `orchid/platform` — Admin panel

--- a/app/Events/FriendRequestAccepted.php
+++ b/app/Events/FriendRequestAccepted.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\Friendship;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class FriendRequestAccepted
+{
+    use Dispatchable, SerializesModels;
+
+    public Friendship $friendship;
+
+    public function __construct(Friendship $friendship)
+    {
+        $this->friendship = $friendship;
+    }
+}

--- a/app/Events/FriendRequestSent.php
+++ b/app/Events/FriendRequestSent.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\Friendship;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class FriendRequestSent
+{
+    use Dispatchable, SerializesModels;
+
+    public Friendship $friendship;
+
+    public function __construct(Friendship $friendship)
+    {
+        $this->friendship = $friendship;
+    }
+}

--- a/app/Http/Controllers/FriendshipController.php
+++ b/app/Http/Controllers/FriendshipController.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Events\FriendRequestAccepted;
+use App\Events\FriendRequestSent;
 use App\Models\Friendship;
 use App\Models\User;
 use Illuminate\Http\Request;
@@ -17,17 +19,35 @@ class FriendshipController extends Controller
     {
         $user = auth()->user();
         $tab = $request->get('tab', 'friends');
+        $search = $request->get('search', '');
 
-        $friends = $user->friends()->paginate(20, ['*'], 'friends_page');
+        $friendsQuery = $user->friends();
+
+        if ($search) {
+            $op = \DB::getDriverName() === 'pgsql' ? 'ilike' : 'like';
+            $friendsQuery->where(function ($q) use ($op, $search) {
+                $q->where('name', $op, "%{$search}%")
+                    ->orWhere('email', $op, "%{$search}%")
+                    ->orWhere('position', $op, "%{$search}%");
+            });
+        }
+
+        $friends = $friendsQuery->paginate(20, ['*'], 'friends_page');
 
         $incoming = $user->pendingFriendRequests()
             ->with('sender')
             ->latest()
             ->get();
 
+        $outgoing = $user->sentFriendRequests()
+            ->where('status', 'pending')
+            ->with('receiver')
+            ->latest()
+            ->get();
+
         $friendsOfFriends = $user->friendsOfFriends(12);
 
-        return view('friends.index', compact('friends', 'incoming', 'friendsOfFriends', 'tab'));
+        return view('friends.index', compact('friends', 'incoming', 'outgoing', 'friendsOfFriends', 'tab', 'search'));
     }
 
     /**
@@ -56,6 +76,7 @@ class FriendshipController extends Controller
             // Если другой пользователь уже отправил нам заявку — автоматически принимаем
             if ($existing->sender_id === $user->id && $existing->isPending()) {
                 $existing->update(['status' => 'accepted']);
+                FriendRequestAccepted::dispatch($existing);
 
                 return back()->with('success', 'Вы теперь друзья!');
             }
@@ -63,11 +84,13 @@ class FriendshipController extends Controller
             return back()->with('info', 'Заявка уже отправлена.');
         }
 
-        Friendship::create([
+        $friendship = Friendship::create([
             'sender_id' => $sender->id,
             'receiver_id' => $user->id,
             'status' => 'pending',
         ]);
+
+        FriendRequestSent::dispatch($friendship);
 
         return back()->with('success', 'Заявка в друзья отправлена!');
     }
@@ -85,6 +108,7 @@ class FriendshipController extends Controller
             ->firstOrFail();
 
         $friendship->update(['status' => 'accepted']);
+        FriendRequestAccepted::dispatch($friendship);
 
         return back()->with('success', 'Заявка принята! Вы теперь друзья.');
     }

--- a/app/Listeners/SendFriendRequestAcceptedNotification.php
+++ b/app/Listeners/SendFriendRequestAcceptedNotification.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\FriendRequestAccepted;
+use App\Notifications\FriendRequestAcceptedNotification;
+
+class SendFriendRequestAcceptedNotification
+{
+    public function handle(FriendRequestAccepted $event): void
+    {
+        $friendship = $event->friendship;
+        $sender = $friendship->sender;
+
+        $sender->notify(new FriendRequestAcceptedNotification($friendship));
+    }
+}

--- a/app/Listeners/SendFriendRequestNotification.php
+++ b/app/Listeners/SendFriendRequestNotification.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\FriendRequestSent;
+use App\Notifications\FriendRequestNotification;
+
+class SendFriendRequestNotification
+{
+    public function handle(FriendRequestSent $event): void
+    {
+        $friendship = $event->friendship;
+        $receiver = $friendship->receiver;
+
+        $receiver->notify(new FriendRequestNotification($friendship));
+    }
+}

--- a/app/Notifications/FriendRequestAcceptedNotification.php
+++ b/app/Notifications/FriendRequestAcceptedNotification.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\Friendship;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class FriendRequestAcceptedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public Friendship $friendship;
+
+    public function __construct(Friendship $friendship)
+    {
+        $this->friendship = $friendship;
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        $accepter = $this->friendship->receiver;
+
+        return [
+            'type' => 'friend_request_accepted',
+            'message' => $accepter->name.' принял(а) вашу заявку в друзья',
+            'accepter_id' => $accepter->id,
+            'accepter_name' => $accepter->name,
+            'url' => route('users.show', $accepter),
+        ];
+    }
+}

--- a/app/Notifications/FriendRequestNotification.php
+++ b/app/Notifications/FriendRequestNotification.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\Friendship;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class FriendRequestNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public Friendship $friendship;
+
+    public function __construct(Friendship $friendship)
+    {
+        $this->friendship = $friendship;
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        $sender = $this->friendship->sender;
+
+        return [
+            'type' => 'friend_request',
+            'message' => $sender->name.' хочет добавить вас в друзья',
+            'sender_id' => $sender->id,
+            'sender_name' => $sender->name,
+            'url' => route('friends.index', ['tab' => 'incoming']),
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,8 @@ namespace App\Providers;
 use App\Events\AuctionTradingStarted;
 use App\Events\CommentCreated;
 use App\Events\CompanyCreated;
+use App\Events\FriendRequestAccepted;
+use App\Events\FriendRequestSent;
 use App\Events\ProjectInvitationSent;
 use App\Events\ProjectJoinRequestCreated;
 use App\Events\ProjectJoinRequestReviewed;
@@ -15,6 +17,8 @@ use App\Events\UserSubscribed;
 use App\Listeners\SendAuctionTradingStartedNotification;
 use App\Listeners\SendCommentNotification;
 use App\Listeners\SendCompanyCreatedNotification;
+use App\Listeners\SendFriendRequestAcceptedNotification;
+use App\Listeners\SendFriendRequestNotification;
 use App\Listeners\SendProjectInvitationNotification;
 use App\Listeners\SendProjectJoinRequestNotification;
 use App\Listeners\SendProjectJoinRequestReviewedNotification;
@@ -111,6 +115,8 @@ class AppServiceProvider extends ServiceProvider
         Event::listen(ProjectJoinRequestCreated::class, SendProjectJoinRequestNotification::class);
         Event::listen(ProjectJoinRequestReviewed::class, SendProjectJoinRequestReviewedNotification::class);
         Event::listen(UserSubscribed::class, SendUserSubscribedNotification::class);
+        Event::listen(FriendRequestSent::class, SendFriendRequestNotification::class);
+        Event::listen(FriendRequestAccepted::class, SendFriendRequestAcceptedNotification::class);
     }
 
     /**

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -4,6 +4,30 @@
 
 ---
 
+## 2026-04-03 — Доработки #126 (Друзья) + #130 (Поиск в шапке)
+
+### #126 — Модуль Друзья: доработки
+- **Таб «Отправленные заявки»** — добавлен 4-й таб с исходящими заявками и кнопкой «Отменить»
+- **Поиск друзей** — поле поиска на табе «Друзья» (по имени, email, должности)
+- **Уведомления** — `FriendRequestNotification` (новая заявка) и `FriendRequestAcceptedNotification` (принятие заявки), события `FriendRequestSent` / `FriendRequestAccepted`, слушатели зарегистрированы в `AppServiceProvider`
+
+**Файлы:**
+- `app/Http/Controllers/FriendshipController.php` — outgoing запрос, поиск, dispatch событий
+- `resources/views/friends/index.blade.php` — таб «Отправленные», поле поиска
+- `app/Events/FriendRequestSent.php`, `app/Events/FriendRequestAccepted.php` — новые события
+- `app/Notifications/FriendRequestNotification.php`, `app/Notifications/FriendRequestAcceptedNotification.php` — уведомления
+- `app/Listeners/SendFriendRequestNotification.php`, `app/Listeners/SendFriendRequestAcceptedNotification.php` — слушатели
+- `app/Providers/AppServiceProvider.php` — регистрация событий
+
+### #130 — Поле поиска в шапке
+- **Десктоп:** расширено поле (`w-64 lg:w-80 xl:w-96`), увеличен padding (`pl-10 pr-8 py-2`), иконка `h-5 w-5` — убрано наслоение placeholder и лупы
+- **Мобилка:** добавлено полноценное поле поиска с выпадающими результатами в мобильном меню
+
+**Файлы:**
+- `resources/views/layouts/navigation.blade.php` — расширение desktop поиска + добавление mobile поиска
+
+---
+
 ## 2026-03-31 — Правки #73, #65 + Модуль Друзья (#126)
 
 ### #73 — Проекты: 500 ошибка при открытии + ограничение комментариев

--- a/resources/views/friends/index.blade.php
+++ b/resources/views/friends/index.blade.php
@@ -29,24 +29,32 @@
             <div x-data="{ tab: '{{ $tab }}' }">
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                     <div class="border-b border-gray-200">
-                        <nav class="flex -mb-px">
+                        <nav class="flex -mb-px overflow-x-auto">
                             <button @click="tab = 'friends'"
                                     :class="tab === 'friends' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'"
-                                    class="flex-1 py-4 px-1 text-center border-b-2 font-medium text-sm transition">
+                                    class="flex-1 py-4 px-1 text-center border-b-2 font-medium text-sm transition whitespace-nowrap">
                                 Друзья
                                 <span class="ml-1 text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">{{ $friends->total() }}</span>
                             </button>
                             <button @click="tab = 'incoming'"
                                     :class="tab === 'incoming' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'"
-                                    class="flex-1 py-4 px-1 text-center border-b-2 font-medium text-sm transition">
-                                Входящие заявки
+                                    class="flex-1 py-4 px-1 text-center border-b-2 font-medium text-sm transition whitespace-nowrap">
+                                Входящие
                                 @if($incoming->count() > 0)
                                     <span class="ml-1 text-xs bg-emerald-100 text-emerald-700 px-2 py-0.5 rounded-full">{{ $incoming->count() }}</span>
                                 @endif
                             </button>
+                            <button @click="tab = 'outgoing'"
+                                    :class="tab === 'outgoing' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'"
+                                    class="flex-1 py-4 px-1 text-center border-b-2 font-medium text-sm transition whitespace-nowrap">
+                                Отправленные
+                                @if($outgoing->count() > 0)
+                                    <span class="ml-1 text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">{{ $outgoing->count() }}</span>
+                                @endif
+                            </button>
                             <button @click="tab = 'suggestions'"
                                     :class="tab === 'suggestions' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'"
-                                    class="flex-1 py-4 px-1 text-center border-b-2 font-medium text-sm transition">
+                                    class="flex-1 py-4 px-1 text-center border-b-2 font-medium text-sm transition whitespace-nowrap">
                                 Рекомендации
                                 @if($friendsOfFriends->count() > 0)
                                     <span class="ml-1 text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">{{ $friendsOfFriends->count() }}</span>
@@ -57,6 +65,32 @@
 
                     {{-- Friends Tab --}}
                     <div x-show="tab === 'friends'" class="p-6">
+                        {{-- Search friends --}}
+                        <form action="{{ route('friends.index') }}" method="GET" class="mb-4">
+                            <input type="hidden" name="tab" value="friends">
+                            <div class="relative">
+                                <input
+                                    type="text"
+                                    name="search"
+                                    value="{{ $search }}"
+                                    placeholder="Поиск среди друзей..."
+                                    class="w-full pl-10 pr-4 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-emerald-500 focus:border-emerald-500"
+                                >
+                                <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                                    <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                                    </svg>
+                                </div>
+                                @if($search)
+                                    <a href="{{ route('friends.index', ['tab' => 'friends']) }}" class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600">
+                                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                        </svg>
+                                    </a>
+                                @endif
+                            </div>
+                        </form>
+
                         @if($friends->isNotEmpty())
                             <div class="space-y-3">
                                 @foreach($friends as $friend)
@@ -84,11 +118,15 @@
                             </div>
 
                             <div class="mt-4">
-                                {{ $friends->links() }}
+                                {{ $friends->appends(['tab' => 'friends', 'search' => $search])->links() }}
                             </div>
                         @else
                             <p class="text-sm text-gray-500 text-center py-8">
-                                У вас пока нет друзей. Добавьте пользователей через их профили или раздел «Рекомендации».
+                                @if($search)
+                                    По запросу «{{ $search }}» ничего не найдено.
+                                @else
+                                    У вас пока нет друзей. Добавьте пользователей через их профили или раздел «Рекомендации».
+                                @endif
                             </p>
                         @endif
                     </div>
@@ -133,6 +171,41 @@
                         @else
                             <p class="text-sm text-gray-500 text-center py-8">
                                 Нет входящих заявок в друзья.
+                            </p>
+                        @endif
+                    </div>
+
+                    {{-- Outgoing Requests Tab --}}
+                    <div x-show="tab === 'outgoing'" class="p-6">
+                        @if($outgoing->isNotEmpty())
+                            <div class="space-y-3">
+                                @foreach($outgoing as $request)
+                                    <div class="flex items-center justify-between p-3 rounded-lg bg-gray-50">
+                                        <a href="{{ route('users.show', $request->receiver) }}" class="flex items-center space-x-3 flex-1 min-w-0">
+                                            <img src="{{ $request->receiver->avatar_url }}" alt=""
+                                                 class="w-10 h-10 rounded-full object-cover flex-shrink-0">
+                                            <div class="min-w-0">
+                                                <p class="text-sm font-medium text-gray-900 truncate">{{ $request->receiver->name }}</p>
+                                                @if($request->receiver->position)
+                                                    <p class="text-xs text-gray-500 truncate">{{ $request->receiver->position }}</p>
+                                                @endif
+                                                <p class="text-xs text-gray-400">{{ $request->created_at->diffForHumans() }}</p>
+                                            </div>
+                                        </a>
+                                        <form action="{{ route('friends.remove', $request->receiver) }}" method="POST">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit"
+                                                class="inline-flex items-center px-3 py-1.5 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-red-100 hover:text-red-700 transition">
+                                                Отменить
+                                            </button>
+                                        </form>
+                                    </div>
+                                @endforeach
+                            </div>
+                        @else
+                            <p class="text-sm text-gray-500 text-center py-8">
+                                Нет отправленных заявок.
                             </p>
                         @endif
                     </div>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -128,11 +128,11 @@
                             @input.debounce.300ms="if(query.length >= 2) { loading = true; fetch('{{ route('search.quick') }}?q=' + encodeURIComponent(query)).then(r => r.json()).then(d => { results = Array.isArray(d) ? d : (d.results || []); loading = false; open = true; }).catch(() => loading = false); } else { results = []; open = false; }"
                             @focus="if(results.length > 0) open = true"
                             @keydown.escape="open = false"
-                            placeholder="Поиск..."
-                            class="w-48 lg:w-64 pl-9 pr-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-emerald-500 focus:border-emerald-500"
+                            placeholder="Поиск компаний, проектов..."
+                            class="w-64 lg:w-80 xl:w-96 pl-10 pr-8 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-emerald-500 focus:border-emerald-500"
                         >
                         <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                            <svg class="h-4 w-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
                             </svg>
                         </div>
@@ -327,6 +327,46 @@
     <!-- Responsive Navigation Menu (Mobile) -->
     {{-- G3: Добавлен скролл для длинного мобильного меню --}}
     <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden max-h-[calc(100vh-4rem)] overflow-y-auto">
+        {{-- Mobile Search --}}
+        <div class="px-4 pt-3 pb-2" x-data="{ query: '', results: [], loading: false, open: false }">
+            <div class="relative">
+                <input
+                    type="text"
+                    x-model="query"
+                    @input.debounce.300ms="if(query.length >= 2) { loading = true; fetch('{{ route('search.quick') }}?q=' + encodeURIComponent(query)).then(r => r.json()).then(d => { results = Array.isArray(d) ? d : (d.results || []); loading = false; open = true; }).catch(() => loading = false); } else { results = []; open = false; }"
+                    @focus="if(results.length > 0) open = true"
+                    placeholder="Поиск..."
+                    class="w-full pl-10 pr-8 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-emerald-500 focus:border-emerald-500"
+                >
+                <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <svg class="h-5 w-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                    </svg>
+                </div>
+                <div x-show="loading" class="absolute inset-y-0 right-0 pr-3 flex items-center">
+                    <svg class="animate-spin h-4 w-4 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                </div>
+            </div>
+            {{-- Mobile Search Results --}}
+            <div x-show="open && results.length > 0" @click.away="open = false" class="mt-2 bg-white rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 max-h-64 overflow-y-auto">
+                <template x-for="result in results" :key="result.type + '-' + result.id">
+                    <a :href="result.url" class="flex items-center px-4 py-2 hover:bg-gray-100 border-b border-gray-50 last:border-0">
+                        <span class="inline-flex items-center justify-center w-8 h-8 rounded-full bg-gray-100 text-gray-600 mr-3 text-xs font-medium flex-shrink-0" x-text="result.type_label.substring(0, 1)"></span>
+                        <div class="flex-1 min-w-0">
+                            <p class="text-sm font-medium text-gray-900 truncate" x-text="result.title"></p>
+                            <p class="text-xs text-gray-500 truncate" x-text="result.subtitle || result.type_label"></p>
+                        </div>
+                    </a>
+                </template>
+                <a :href="'{{ route('search.index') }}?q=' + encodeURIComponent(query)" class="block px-4 py-2 text-center text-sm text-emerald-600 hover:text-emerald-800 border-t border-gray-100 bg-gray-50">
+                    {{ __('Все результаты') }}
+                </a>
+            </div>
+        </div>
+
         <div class="pt-2 pb-3 space-y-1">
             <!-- Компании -->
             <x-responsive-nav-link :href="route('companies.index')" :active="request()->routeIs('companies.*')">


### PR DESCRIPTION
## Summary
- **#126 Друзья:** таб «Отправленные заявки», поиск по друзьям, уведомления при заявке/принятии
- **#130 Поиск в шапке:** расширено поле на десктопе, убрано наслоение placeholder/иконки, добавлен поиск в мобильном меню

Closes #126
Closes #130

## Test plan
- [ ] Открыть /friends — проверить 4 таба (Друзья, Входящие, Отправленные, Рекомендации)
- [ ] Отправить заявку в друзья — проверить уведомление у получателя
- [ ] Принять заявку — проверить уведомление у отправителя
- [ ] Ввести текст в поиск друзей — фильтрация работает
- [ ] Desktop: поле поиска в шапке шире, нет наслоения текста и иконки
- [ ] Mobile: открыть гамбургер — поле поиска вверху, результаты показываются

🤖 Generated with [Claude Code](https://claude.com/claude-code)