### PR TITLE
fix: модератор компании может добавлять участников (#74)

### DIFF
--- a/app/Http/Controllers/CompanyModeratorController.php
+++ b/app/Http/Controllers/CompanyModeratorController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Models\Company;
 use App\Models\User;
-use Illuminate\Http\Request;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\Request;
 
 class CompanyModeratorController extends Controller
 {
@@ -16,13 +16,17 @@ class CompanyModeratorController extends Controller
      */
     public function store(Request $request, Company $company)
     {
-        if (!$company->canManageModerators(auth()->user())) {
-            abort(403, 'У вас нет прав для управления модераторами этой компании');
+        $actor = auth()->user();
+
+        if (! $company->canAddMember($actor)) {
+            abort(403, 'У вас нет прав для добавления участников этой компании');
         }
+
+        $assignableRoles = $company->getAssignableMemberRoles($actor);
 
         $validated = $request->validate([
             'user_id' => 'required|exists:users,id',
-            'role' => 'nullable|string|max:100',
+            'role' => ['nullable', 'string', 'in:'.implode(',', array_keys($assignableRoles))],
             'can_manage_moderators' => 'boolean',
         ]);
 
@@ -33,11 +37,16 @@ class CompanyModeratorController extends Controller
             return back()->with('error', 'Этот пользователь уже является модератором компании');
         }
 
+        // Обычный модератор не может выдавать флаг can_manage_moderators
+        $canManageFlag = $company->canManageModerators($actor)
+            ? ($validated['can_manage_moderators'] ?? false)
+            : false;
+
         $company->assignModerator(
             $user,
-            $validated['role'] ?? 'moderator',
-            auth()->user(),
-            $validated['can_manage_moderators'] ?? false
+            $validated['role'] ?? 'member',
+            $actor,
+            $canManageFlag
         );
 
         // TODO: Отправить уведомление пользователю (Спринт 7)
@@ -50,7 +59,7 @@ class CompanyModeratorController extends Controller
      */
     public function update(Request $request, Company $company, User $user)
     {
-        if (!$company->canManageModerators(auth()->user())) {
+        if (! $company->canManageModerators(auth()->user())) {
             abort(403, 'У вас нет прав для управления модераторами этой компании');
         }
 
@@ -72,7 +81,7 @@ class CompanyModeratorController extends Controller
      */
     public function destroy(Company $company, User $user)
     {
-        if (!$company->canManageModerators(auth()->user())) {
+        if (! $company->canManageModerators(auth()->user())) {
             abort(403, 'У вас нет прав для управления модераторами этой компании');
         }
 

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -195,6 +195,36 @@ class Company extends Model implements HasMedia
     }
 
     /**
+     * Может ли пользователь добавлять новых участников в компанию (#74).
+     * Расширяет canManageModerators: обычный модератор тоже может добавлять,
+     * но только с ролью «member» (см. getAssignableMemberRoles).
+     */
+    public function canAddMember(User $user): bool
+    {
+        if ($this->canManageModerators($user)) {
+            return true;
+        }
+
+        return $this->isModerator($user);
+    }
+
+    /**
+     * Роли, которые данный пользователь имеет право назначать при добавлении.
+     * Менеджеры (владелец / can_manage_moderators) — все роли;
+     * обычный модератор — только «Участник».
+     */
+    public function getAssignableMemberRoles(User $user): array
+    {
+        $all = ['admin' => 'Админ', 'moderator' => 'Модератор', 'member' => 'Участник'];
+
+        if ($this->canManageModerators($user)) {
+            return $all;
+        }
+
+        return ['member' => 'Участник'];
+    }
+
+    /**
      * Проверка: есть ли активный запрос от пользователя
      */
     public function hasPendingRequestFrom(User $user): bool

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -1506,3 +1506,16 @@ SESSION_SECURE_COOKIE=true
 
 **Изменённые файлы:**
 - `resources/views/profile/keywords.blade.php` — правка текста в блоке «Как работает фильтрация?»
+
+---
+
+## 2026-04-13: Модератор компании видит поле «Добавить участника» (#74)
+
+**Что сделано:** Обычный модератор компании (без флага `can_manage_moderators`) теперь видит форму «Добавить участника» на странице компании в вкладке «Люди» и может добавлять пользователей с ролью «Участник». Назначение ролей «Админ» и «Модератор» по-прежнему только у владельца / менеджеров (`canManageModerators`).
+
+**Причина:** заказчик сообщил, что после PR #135 (проектные модераторы) форма добавления всё ещё не появляется у обычного модератора на странице компании — PR #135 покрывал только проекты, а жалоба была по `/companies/{slug}`.
+
+**Изменённые файлы:**
+- `app/Models/Company.php` — методы `canAddMember()` и `getAssignableMemberRoles()`
+- `app/Http/Controllers/CompanyModeratorController.php` — `store()` теперь использует `canAddMember` и валидирует роль через `getAssignableMemberRoles`, обычный модератор не может выдавать флаг `can_manage_moderators`
+- `resources/views/companies/show.blade.php` — форма гейтится на `canAddCompanyMember`, dropdown ролей берётся из `assignableMemberRoles`, для обычного модератора показывается подсказка

--- a/resources/views/companies/show.blade.php
+++ b/resources/views/companies/show.blade.php
@@ -310,6 +310,10 @@
                 <div id="content-people" class="tab-content hidden">
                     @php
                         $canManagePeople = auth()->check() && $company->canManageModerators(auth()->user());
+                        $canAddCompanyMember = auth()->check() && $company->canAddMember(auth()->user());
+                        $assignableMemberRoles = auth()->check()
+                            ? $company->getAssignableMemberRoles(auth()->user())
+                            : [];
                         $roleLabels = ['owner' => 'Владелец', 'admin' => 'Админ', 'moderator' => 'Модератор', 'member' => 'Участник'];
                         $roleBadgeColors = [
                             'owner' => 'bg-green-100 text-green-800',
@@ -320,10 +324,13 @@
                         $editableRoles = ['admin' => 'Админ', 'moderator' => 'Модератор', 'member' => 'Участник'];
                     @endphp
 
-                    {{-- #71: Форма добавления участника (по аналогии с проектами) --}}
-                    @if($canManagePeople)
+                    {{-- #71/#74: Форма добавления участника (по аналогии с проектами) --}}
+                    @if($canAddCompanyMember)
                         <div class="mb-6 p-4 bg-gray-50 rounded-lg" x-data="companyUserSearch()">
                             <h4 class="text-sm font-semibold text-gray-700 mb-3">Добавить участника</h4>
+                            @if(!$canManagePeople)
+                                <p class="text-xs text-gray-500 mb-3">Вы можете добавлять пользователей в компанию с ролью «Участник»</p>
+                            @endif
                             <form method="POST" action="{{ route('companies.moderators.store', $company) }}">
                                 @csrf
                                 <input type="hidden" name="user_id" x-model="selectedUserId">
@@ -369,7 +376,7 @@
                                     </div>
                                     <div>
                                         <select name="role" class="rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500 text-sm">
-                                            @foreach($editableRoles as $value => $label)
+                                            @foreach($assignableMemberRoles as $value => $label)
                                                 <option value="{{ $value }}" {{ $value === 'member' ? 'selected' : '' }}>{{ $label }}</option>
                                             @endforeach
                                         </select>


### PR DESCRIPTION
## Summary
- `Company::canAddMember()` — обычный модератор компании теперь имеет право добавлять участников
- `Company::getAssignableMemberRoles()` — обычный модератор может назначать только роль «Участник»; владелец / менеджеры — все роли
- `CompanyModeratorController::store()` валидирует роль и не даёт обычному модератору выдавать `can_manage_moderators`
- На странице компании в «Люди» форма «Добавить участника» теперь видна обычному модератору с подсказкой об ограничении

По жалобе заказчика в #74: после PR #135 (который покрывал только проекты) форма всё ещё не появлялась у обычного модератора на странице `/companies/{slug}`.

Relates to #74

## Test plan
- [ ] Обычный модератор компании видит форму «Добавить участника» на вкладке «Люди»
- [ ] Модератор может добавить пользователя с ролью «Участник»
- [ ] В dropdown у модератора доступна только роль «Участник»
- [ ] Владелец / менеджер по-прежнему видит все роли
- [ ] Попытка POST с ролью admin/moderator от обычного модератора возвращает ошибку валидации
- [ ] Обычный модератор не может выдавать флаг can_manage_moderators

🤖 Generated with [Claude Code](https://claude.com/claude-code)