### PR TITLE
fix(#143): убрать дубли уведомлений

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ php artisan tinker
 ```
 app/
 ├── Services/       # Business logic: RfqScoringService, AuctionWinnerService, *ProtocolService, NewsFilterService
-├── Events/         # Domain events (registered in AppServiceProvider@registerEventListeners)
+├── Events/         # Domain events (listeners auto-discovered from app/Listeners)
 ├── Listeners/      # Send*Notification handlers
 ├── Jobs/           # CloseAuctionJob, CloseRfqJob, UpdateAuctionStatuses, NotifyAdminOnRSSErrorJob
 ├── Policies/       # RfqPolicy, AuctionPolicy (registered via Gate::policy in AppServiceProvider)
@@ -124,7 +124,7 @@ app/
 ```
 
 ### Event-Driven Architecture
-All event→listener mappings are registered in `AppServiceProvider@registerEventListeners()`. Pattern: domain `Event` classes in `app/Events/` are handled by `Send*Notification` listeners in `app/Listeners/`. Check that method for the authoritative list.
+Event→listener wiring uses Laravel's **automatic listener discovery** (Laravel 11+): each `Send*Notification` listener in `app/Listeners/` is auto-registered for the event its `handle()` type-hints. Do NOT also register them manually with `Event::listen` — that double-registers the listener and fires it twice (see #143). Pattern: domain `Event` classes in `app/Events/` → `Send*Notification` listeners in `app/Listeners/`.
 
 ### Key Packages
 - `orchid/platform` — Admin panel

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,38 +2,11 @@
 
 namespace App\Providers;
 
-use App\Events\AuctionTradingStarted;
-use App\Events\CommentCreated;
-use App\Events\CompanyCreated;
-use App\Events\FriendRequestAccepted;
-use App\Events\FriendRequestSent;
-use App\Events\ProjectInvitationSent;
-use App\Events\ProjectJoinRequestCreated;
-use App\Events\ProjectJoinRequestReviewed;
-use App\Events\ProjectUserInvited;
-use App\Events\TenderClosed;
-use App\Events\TenderInvitationSent;
-use App\Events\UserSubscribed;
-use App\Listeners\SendAuctionTradingStartedNotification;
-use App\Listeners\SendCommentNotification;
-use App\Listeners\SendCompanyCreatedNotification;
-use App\Listeners\SendFriendRequestAcceptedNotification;
-use App\Listeners\SendFriendRequestNotification;
-use App\Listeners\SendProjectInvitationNotification;
-use App\Listeners\SendProjectJoinRequestNotification;
-use App\Listeners\SendProjectJoinRequestReviewedNotification;
-use App\Listeners\SendProjectUserInvitedNotification;
-use App\Listeners\SendTenderClosedNotification;
-use App\Listeners\SendTenderInvitationNotification;
-use App\Listeners\SendUserSubscribedNotification;
-// Events
 use App\Models\Auction;
 use App\Models\Company;
 use App\Models\Rfq;
 use App\Policies\AuctionPolicy;
-// Listeners
 use App\Policies\RfqPolicy;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\URL;
@@ -57,7 +30,6 @@ class AppServiceProvider extends ServiceProvider
         $this->configureSocialite();
         $this->configureHttps();
         $this->registerPolicies();
-        $this->registerEventListeners();
         $this->registerRouteBindings();
     }
 
@@ -98,25 +70,6 @@ class AppServiceProvider extends ServiceProvider
     {
         Gate::policy(Rfq::class, RfqPolicy::class);
         Gate::policy(Auction::class, AuctionPolicy::class);
-    }
-
-    /**
-     * Register event listeners.
-     */
-    protected function registerEventListeners(): void
-    {
-        Event::listen(ProjectInvitationSent::class, SendProjectInvitationNotification::class);
-        Event::listen(TenderInvitationSent::class, SendTenderInvitationNotification::class);
-        Event::listen(CommentCreated::class, SendCommentNotification::class);
-        Event::listen(TenderClosed::class, SendTenderClosedNotification::class);
-        Event::listen(AuctionTradingStarted::class, SendAuctionTradingStartedNotification::class);
-        Event::listen(CompanyCreated::class, SendCompanyCreatedNotification::class);
-        Event::listen(ProjectUserInvited::class, SendProjectUserInvitedNotification::class);
-        Event::listen(ProjectJoinRequestCreated::class, SendProjectJoinRequestNotification::class);
-        Event::listen(ProjectJoinRequestReviewed::class, SendProjectJoinRequestReviewedNotification::class);
-        Event::listen(UserSubscribed::class, SendUserSubscribedNotification::class);
-        Event::listen(FriendRequestSent::class, SendFriendRequestNotification::class);
-        Event::listen(FriendRequestAccepted::class, SendFriendRequestAcceptedNotification::class);
     }
 
     /**

--- a/tests/Feature/NotificationTest.php
+++ b/tests/Feature/NotificationTest.php
@@ -21,6 +21,24 @@ class NotificationTest extends TestCase
         $this->user = User::factory()->create();
     }
 
+    public function test_event_creates_exactly_one_notification(): void
+    {
+        // Regression for #143: listeners were registered both manually in
+        // AppServiceProvider AND auto-discovered by Laravel, so every event
+        // fired its listener twice and stored two identical notifications.
+        $sender = User::factory()->create();
+        $receiver = User::factory()->create();
+        $friendship = \App\Models\Friendship::create([
+            'sender_id' => $sender->id,
+            'receiver_id' => $receiver->id,
+            'status' => 'pending',
+        ]);
+
+        \App\Events\FriendRequestSent::dispatch($friendship);
+
+        $this->assertCount(1, $receiver->fresh()->notifications);
+    }
+
     public function test_user_can_view_notifications_page(): void
     {
         $response = $this->actingAs($this->user)


### PR DESCRIPTION
Closes #143. Слушатели регистрировались дважды: авто-discovery Laravel 11 + ручной Event::listen в AppServiceProvider. Каждое событие срабатывало 2 раза → 2 одинаковых уведомления. Убрал ручную регистрацию, добавил регресс-тест.