### PR TITLE
fix(#144): роль нового участника компании по умолчанию — Участник

### DIFF
--- a/app/Http/Controllers/CompanyJoinRequestController.php
+++ b/app/Http/Controllers/CompanyJoinRequestController.php
@@ -95,10 +95,12 @@ class CompanyJoinRequestController extends Controller
         DB::beginTransaction();
 
         try {
-            // Добавляем пользователя как модератора
+            // Добавляем пользователя в компанию.
+            // #144: по умолчанию роль «Участник», а не желаемая роль из запроса,
+            // чтобы пользователь не мог сам себе назначить админа/модератора.
             $joinRequest->company->assignModerator(
                 $joinRequest->user,
-                $validated['role'] ?? $joinRequest->desired_role,
+                ! empty($validated['role']) ? $validated['role'] : 'member',
                 auth()->user(),
                 $validated['can_manage_moderators'] ?? false
             );

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -246,7 +246,8 @@ class Company extends Model implements HasMedia
         }
 
         $this->moderators()->attach($user->id, [
-            'role' => $role ?? 'moderator',
+            // #144: new members default to "Участник" (member), not moderator
+            'role' => $role ?: 'member',
             'added_by' => $addedBy?->id ?? auth()->id(),
             'added_at' => now(),
             'can_manage_moderators' => $canManageModerators,

--- a/resources/views/companies/show.blade.php
+++ b/resources/views/companies/show.blade.php
@@ -614,7 +614,7 @@
                            id="approve_role"
                            placeholder="Например: Менеджер"
                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
-                    <p class="text-xs text-gray-500 mt-1">Оставьте пустым, чтобы использовать роль из запроса</p>
+                    <p class="text-xs text-gray-500 mt-1">Оставьте пустым, чтобы назначить роль «Участник»</p>
                 </div>
 
                 <div class="flex justify-end space-x-2">

--- a/tests/Feature/CompanyTest.php
+++ b/tests/Feature/CompanyTest.php
@@ -428,6 +428,13 @@ class CompanyTest extends TestCase
 
         // Проверяем, что пользователь стал модератором
         $this->assertTrue($company->fresh()->isModerator($applicant));
+
+        // #144: без явной роли пользователь добавляется как «Участник» (member)
+        $this->assertDatabaseHas('company_user', [
+            'company_id' => $company->id,
+            'user_id' => $applicant->id,
+            'role' => 'member',
+        ]);
     }
 
     public function test_moderator_can_reject_join_request(): void


### PR DESCRIPTION
Closes #144. assignModerator по умолчанию ставил 'moderator', а одобрение заявки использовало желаемую роль из запроса (можно было самоназначить админа). Теперь по умолчанию 'member'.