### PR TITLE
feat(#142): поиск друзей по всем пользователям сайта

### DIFF
--- a/app/Http/Controllers/FriendshipController.php
+++ b/app/Http/Controllers/FriendshipController.php
@@ -21,18 +21,20 @@ class FriendshipController extends Controller
         $tab = $request->get('tab', 'friends');
         $search = $request->get('search', '');
 
-        $friendsQuery = $user->friends();
-
-        if ($search) {
+        // #142: при поиске ищем по всем пользователям сайта (чтобы находить новых друзей),
+        // без поиска — показываем список текущих друзей. Email в поиске не используем (#139).
+        if ($search !== '') {
             $op = \DB::getDriverName() === 'pgsql' ? 'ilike' : 'like';
-            $friendsQuery->where(function ($q) use ($op, $search) {
-                $q->where('name', $op, "%{$search}%")
-                    ->orWhere('email', $op, "%{$search}%")
-                    ->orWhere('position', $op, "%{$search}%");
-            });
+            $friends = User::where('id', '!=', $user->id)
+                ->where(function ($q) use ($op, $search) {
+                    $q->where('name', $op, "%{$search}%")
+                        ->orWhere('position', $op, "%{$search}%");
+                })
+                ->orderBy('name')
+                ->paginate(20, ['*'], 'friends_page');
+        } else {
+            $friends = $user->friends()->paginate(20, ['*'], 'friends_page');
         }
-
-        $friends = $friendsQuery->paginate(20, ['*'], 'friends_page');
 
         $incoming = $user->pendingFriendRequests()
             ->with('sender')
@@ -47,7 +49,10 @@ class FriendshipController extends Controller
 
         $friendsOfFriends = $user->friendsOfFriends(12);
 
-        return view('friends.index', compact('friends', 'incoming', 'outgoing', 'friendsOfFriends', 'tab', 'search'));
+        // Реальное число друзей для бейджа вкладки (не зависит от поиска по всем пользователям).
+        $friendsCount = $user->friends()->count();
+
+        return view('friends.index', compact('friends', 'incoming', 'outgoing', 'friendsOfFriends', 'tab', 'search', 'friendsCount'));
     }
 
     /**

--- a/resources/views/friends/index.blade.php
+++ b/resources/views/friends/index.blade.php
@@ -34,7 +34,7 @@
                                     :class="tab === 'friends' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'"
                                     class="flex-1 py-4 px-1 text-center border-b-2 font-medium text-sm transition whitespace-nowrap">
                                 Друзья
-                                <span class="ml-1 text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">{{ $friends->total() }}</span>
+                                <span class="ml-1 text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">{{ $friendsCount }}</span>
                             </button>
                             <button @click="tab = 'incoming'"
                                     :class="tab === 'incoming' ? 'border-emerald-500 text-emerald-600' : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'"
@@ -73,7 +73,7 @@
                                     type="text"
                                     name="search"
                                     value="{{ $search }}"
-                                    placeholder="Поиск среди друзей..."
+                                    placeholder="Поиск по всем пользователям сайта..."
                                     class="w-full pl-10 pr-4 py-2 text-sm border border-gray-300 rounded-lg focus:outline-none focus:ring-1 focus:ring-emerald-500 focus:border-emerald-500"
                                 >
                                 <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -105,14 +105,8 @@
                                                 @endif
                                             </div>
                                         </a>
-                                        <form action="{{ route('friends.remove', $friend) }}" method="POST">
-                                            @csrf
-                                            @method('DELETE')
-                                            <button type="submit"
-                                                class="inline-flex items-center px-3 py-1.5 bg-gray-200 border border-transparent rounded-md font-semibold text-xs text-gray-700 uppercase tracking-widest hover:bg-red-100 hover:text-red-700 transition">
-                                                Удалить
-                                            </button>
-                                        </form>
+                                        {{-- #142: статус-зависимая кнопка (В друзьях / Добавить / Заявка отправлена / Принять) --}}
+                                        <x-friendship-button :user="$friend" />
                                     </div>
                                 @endforeach
                             </div>

--- a/tests/Feature/FriendshipTest.php
+++ b/tests/Feature/FriendshipTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FriendshipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_friends_page_loads(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($user)
+            ->get(route('friends.index'))
+            ->assertStatus(200)
+            ->assertViewIs('friends.index');
+    }
+
+    public function test_friends_search_finds_any_site_user(): void
+    {
+        // #142: поиск на странице друзей ищет по всем пользователям сайта,
+        // а не только среди существующих друзей.
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $stranger = User::factory()->create(['name' => 'Иван Незнакомцев']);
+
+        $this->actingAs($user)
+            ->get(route('friends.index', ['search' => 'Незнакомцев']))
+            ->assertStatus(200)
+            ->assertSee('Иван Незнакомцев');
+    }
+}


### PR DESCRIPTION
Closes #142. Поле поиска на /friends теперь ищет по всем пользователям сайта (имя/должность), а не только среди друзей. Кнопка действия зависит от статуса связи.