### PR TITLE
feat(#179): коммерческий аукцион — каталог, навигация, docs (slice 7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ php artisan tinker
 - **Projects** — Company invitations, user members (roles: admin/moderator/member), join requests, comments. Routes use `{project:slug}` (not ID)
 - **RFQ (Запрос цен)** — Weighted scoring criteria, auto-calculation, PDF protocols
 - **Auction (Аукционы)** — Real-time trading (long-polling), anonymized participants, PDF protocols
+- **Commercial Auction (Коммерческий аукцион)** — Two-stage procedure (#179): `Rfq`/`Auction` with `procedure='commercial'`. Stage 1 = price-only RFQ that auto-launches Stage 2 (`CommercialAuctionLauncherService`, НМЦ = max stage-1 price) — a multi-criteria (price/deadline/advance) real-time auction with continuous-leadership scoring (`CommercialAuctionScoringService`), offers via `AuctionController::storeOffer` (route `auctions.offers.store`, lockForUpdate), UI partial `auctions/partials/commercial-trading`, own protocol (`CommercialAuctionProtocolService`). Standard RFQs/auctions use `procedure='standard'` and are unaffected.
 - **News** — RSS aggregator with keyword filtering, personalized feed. `RSSSource` managed via Orchid admin
 - **Posts** — Social-media-style posts on dashboard feed (create/delete)
 - **Search** — Search via model `scopeSearch()` with `ilike`/`like` queries (Scout uses `collection` driver; search is not index-based)

--- a/app/Http/Controllers/TenderController.php
+++ b/app/Http/Controllers/TenderController.php
@@ -223,6 +223,11 @@ class TenderController extends Controller
         if ($request->filled('type')) {
             $query->where('type', $request->type);
         }
+
+        // #179 Фильтр по виду процедуры (standard / commercial)
+        if ($request->filled('procedure')) {
+            $query->where('procedure', $request->procedure);
+        }
     }
 
     /**

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -1715,3 +1715,43 @@ Pint чист. Ассеты не пересобирались (стили — и
 **Примечание об окружении:** локальный прогон делался в контейнере `php:8.2-cli` без расширения
 `gd`, из-за чего 2 теста генерации PDF-протоколов (`CommercialAuctionTest`, `AuctionTest`) падают —
 это не связано с бейджами и воспроизводится на чистом коде; на образе приложения (с `gd`) и в CI они зелёные.
+
+---
+
+## 2026-07-13 — Коммерческий аукцион (#179), двухэтапная процедура
+
+Новый вид тендера: этап 1 — Запрос цен (только цена, обезличенно, без промежуточного
+протокола) → автоматически этап 2 — коммерческий аукцион в реальном времени по трём
+критериям (цена, срок, аванс) с принципом непрерывного лидерства. Ветка
+`feat/commercial-auction`, 7 слайсов. Архитектура — расширение существующих `Rfq`/`Auction`
+(дискриминатор `procedure`), связанная пара RFQ↔Auction.
+
+**Данные:** миграции добавляют `procedure` + параметры этапа 2 в `rfqs`
+(`trading_start/end`, `step_*`, `max_deadline/advance`, `linked_auction_id`), в `auctions`
+(`rfq_id`, веса/шаги/референсы, `best_bid_id`) и критерии/`total_score`/`is_base`/
+`became_best_at` в `auction_bids`; `rfq_bids.deadline/advance_percent` → nullable.
+
+**Движок:** `CommercialAuctionScoringService` — фиксированная нормировка от референсов,
+итоговый балл по весам, приём «строго лучше», пороги «Уменьшите до X» (замкнутая форма).
+
+**Backend:** `CommercialAuctionLauncherService` (авто-запуск этапа 2, НМЦ = макс. цена
+этапа 1); ветки в `CloseRfqJob`, `UpdateAuctionStatuses` (закрытие по `trading_end`),
+`AuctionWinnerService` (победитель = лучшее предложение); `AuctionController::storeOffer`
+(lockForUpdate, приём/отклонение) + расширенный `getState`; `StoreCommercialOfferRequest`;
+маршрут `auctions.offers.store`.
+
+**Frontend:** переключатель процедуры + параметры этапа 2 в `rfqs/create`; форма заявки
+этапа 1 «только цена»; партиал `auctions/partials/commercial-trading` («Настройка
+предложения»: 3 критерия, слайдеры, диапазоны, подсказки, зеркало скоринга в Alpine,
+long-poll, гейтинг кнопки, история лучших); метки в карточках + фильтр `procedure` в
+каталоге; баннер этап 1→2.
+
+**Протокол:** `CommercialAuctionProtocolService` + `pdfs/commercial-auction-protocol`
+(победитель с ИНН, итоговые значения, рейтинг, история лучших).
+
+**Тесты:** `tests/Feature/CommercialAuctionTest.php` (19) + `tests/Unit/CommercialAuctionScoringServiceTest.php` (8).
+Полный прогон: 308 тестов зелёные. Pint чист.
+
+**Примечание о git:** из-за параллельной работы над репозиторием слайс 6 (`73d58a2`) случайно
+захватил в тот же коммит фичу «Бейджи пользователей» (UserBadge). Историю не переписывал —
+UserBadge оставлен как есть. Слайс 7 сделан в изолированном git worktree.

--- a/resources/views/components/auction-card.blade.php
+++ b/resources/views/components/auction-card.blade.php
@@ -36,9 +36,15 @@
         @endphp
 
         <div class="flex items-center flex-wrap gap-2 mb-2">
-            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
-                Аукцион
-            </span>
+            @if($auction->isCommercial())
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                    Коммерческий аукцион · Этап 2
+                </span>
+            @else
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                    Аукцион
+                </span>
+            @endif
             <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium {{ $statusColor }}">
                 {{ $statusLabel }}
             </span>

--- a/resources/views/components/rfq-card.blade.php
+++ b/resources/views/components/rfq-card.blade.php
@@ -15,9 +15,15 @@
 
         <!-- Номер и статус -->
         <div class="flex items-center flex-wrap gap-2 mb-4">
-            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-800">
-                Запрос цен
-            </span>
+            @if($rfq->isCommercial())
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800">
+                    Коммерческий аукцион · Этап 1
+                </span>
+            @else
+                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-emerald-100 text-emerald-800">
+                    Запрос цен
+                </span>
+            @endif
             <span class="text-sm text-gray-500 font-mono">{{ $rfq->number }}</span>
             @php
                 // Определяем статус с учётом дат

--- a/resources/views/rfqs/show.blade.php
+++ b/resources/views/rfqs/show.blade.php
@@ -97,6 +97,25 @@
             </div>
         @endif
 
+        {{-- #179 Коммерческий аукцион: переход к запущенному этапу 2 --}}
+        @if($rfq->isCommercial() && $rfq->linked_auction_id)
+            <div class="bg-amber-50 border border-amber-200 text-amber-900 rounded-lg p-4 mb-6 flex items-center justify-between gap-4">
+                <div>
+                    <strong>Этап 1 завершён.</strong> Запущен коммерческий аукцион (этап 2) — торги по цене, сроку и авансу.
+                </div>
+                <a href="{{ route('auctions.show', $rfq->linked_auction_id) }}"
+                   class="inline-flex items-center px-4 py-2 bg-amber-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-amber-700 transition whitespace-nowrap">
+                    Перейти к аукциону
+                </a>
+            </div>
+        @elseif($rfq->isCommercial())
+            <div class="bg-amber-50 border border-amber-200 text-amber-900 rounded-lg p-4 mb-6">
+                <strong>Коммерческий аукцион — этап 1 (Запрос цен).</strong>
+                На этом этапе оценивается только цена. После окончания приёма заявок автоматически начнётся этап 2 —
+                торги по цене, сроку и авансу.
+            </div>
+        @endif
+
         <!-- Главная информация -->
         <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg mb-6">
             <div class="p-6">

--- a/tests/Feature/CommercialAuctionTest.php
+++ b/tests/Feature/CommercialAuctionTest.php
@@ -452,6 +452,52 @@ class CommercialAuctionTest extends TestCase
     }
 
     // =========================================================
+    // Слайс 7 — каталог/навигация
+    // =========================================================
+
+    public function test_tenders_catalog_filters_by_procedure(): void
+    {
+        // Один коммерческий и один обычный активный RFQ.
+        $commercial = $this->closeableCommercialRfq([500_000]);
+        $commercial->update(['status' => 'active', 'end_date' => now()->addDay(), 'title' => 'КА в каталоге']);
+
+        $standard = Rfq::create([
+            'number' => Rfq::generateNumber(),
+            'title' => 'Обычный RFQ в каталоге',
+            'company_id' => $this->company->id,
+            'created_by' => $this->user->id,
+            'type' => 'open',
+            'procedure' => Rfq::PROCEDURE_STANDARD,
+            'start_date' => now()->subDay(),
+            'end_date' => now()->addDay(),
+            'weight_price' => 50, 'weight_deadline' => 30, 'weight_advance' => 20,
+            'status' => 'active',
+        ]);
+
+        // Фильтр commercial показывает только коммерческий.
+        $this->get(route('tenders.index', ['procedure' => 'commercial']))
+            ->assertOk()
+            ->assertSee('КА в каталоге')
+            ->assertDontSee('Обычный RFQ в каталоге');
+
+        // Карточка коммерческого RFQ несёт метку этапа 1.
+        $this->get(route('tenders.index', ['procedure' => 'commercial']))
+            ->assertSee('Коммерческий аукцион · Этап 1');
+    }
+
+    public function test_stage_1_page_links_to_launched_auction(): void
+    {
+        $rfq = $this->closeableCommercialRfq([700_000, 900_000]);
+        $this->runCloseRfqJob($rfq);
+        $rfq->refresh();
+
+        $this->get(route('rfqs.show', $rfq))
+            ->assertOk()
+            ->assertSee('Перейти к аукциону')
+            ->assertSee(route('auctions.show', $rfq->linked_auction_id), false);
+    }
+
+    // =========================================================
     // Слайс 6 — протокол
     // =========================================================
 


### PR DESCRIPTION
## Summary
Завершающая часть коммерческого аукциона (#179) поверх уже влитого PR #199 (слайсы 1–6).

- **Слайс 7:** метки «Коммерческий аукцион · Этап 1/2» в карточках RFQ/аукциона; фильтр каталога тендеров по `procedure`; баннер перехода этап 1 → этап 2 на странице RFQ.
- **Документация:** запись в `docs/CHANGELOG_CLAUDE.md` и раздел в `CLAUDE.md` про двухэтапную процедуру, новые сервисы/джобы/маршрут.
- 2 feature-теста (фильтр каталога по procedure, ссылка этап 1→2).

С этим слайсом фича #179 функционально завершена (создание → авто-запуск этапа 2 → торги в реальном времени по 3 критериям → протокол → каталог/навигация).

Closes #179

## Test plan
- [x] Полный прогон тестов: **308 зелёных** (в т.ч. `CommercialAuctionTest` 19 + `CommercialAuctionScoringServiceTest` 8).
- [x] Pint чист.
- [ ] Ручная проверка на test.bizzio.ru: создать коммерческий RFQ → дождаться закрытия этапа 1 → авто-запуск этапа 2 → подать предложения от 2 компаний (подсказки/диапазоны/смена лидера) → закрытие по времени → протокол.

🤖 Generated with [Claude Code](https://claude.com/claude-code)