### PR TITLE
fix(#226): defer у виджета AI-чата также в guest-лейауте и welcome

### DIFF
--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -2199,3 +2199,16 @@ Alpine была мертва**: не открывались меню (особе
 
 **Файлы:** `resources/views/layouts/app.blade.php`, `resources/css/app.css`,
 `public/build/*` (пересобрано).
+
+---
+
+## 2026-07-29 — fix #226 (продолжение): defer у виджета также в guest-лейауте и на welcome
+
+Первый фикс #226 добавил `defer` только в `layouts/app.blade.php`. Виджет AI-чата
+дублируется ещё в двух местах, которые остались render-blocking:
+- `resources/views/layouts/guest.blade.php` (страницы входа/регистрации),
+- `resources/views/welcome.blade.php` (публичная посадочная `bizzio.ru/`).
+
+Обнаружено при проверке живого прода: `curl https://bizzio.ru/` отдавал `<script>` виджета
+без `defer`. Добавлен `defer` во все три места (проверено: не осталось ни одного
+недеферренного вхождения). Ассеты не менялись.

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -56,6 +56,7 @@
     </div>
 
     <!-- AI Chat Widget -->
-    <script src="https://ai-sekretar24.ru/widget.js?instance=bizzio"></script>
+    {{-- #226: defer — render-blocking сторонний скрипт иначе стопорит парсинг/Alpine, если хост недоступен. --}}
+    <script defer src="https://ai-sekretar24.ru/widget.js?instance=bizzio"></script>
 </body>
 </html>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -273,6 +273,7 @@
     <script src="{{ asset('js/custom.js') }}"></script>
 
     <!-- AI Chat Widget -->
-    <script src="https://ai-sekretar24.ru/widget.js?instance=bizzio"></script>
+    {{-- #226: defer — render-blocking сторонний скрипт иначе стопорит парсинг/Alpine, если хост недоступен. --}}
+    <script defer src="https://ai-sekretar24.ru/widget.js?instance=bizzio"></script>
 </body>
 </html>


### PR DESCRIPTION
Дополнение к #227. Виджет AI-чата дублируется в 3 местах; первый фикс закрыл только `layouts/app.blade.php`. `layouts/guest.blade.php` (вход/регистрация) и `welcome.blade.php` (публичная `bizzio.ru/`) оставались render-blocking — обнаружено на живом проде (`curl https://bizzio.ru/` отдавал `<script>` без defer). Добавлен `defer` во все три. Ассеты не менялись.

Relates to #226