### PR TITLE
fix(commercial): #232 HTML5 step-валидация блокировала подачу предложения

### DIFF
--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -2297,3 +2297,27 @@ Alpine была мертва**: не открывались меню (особе
 
 **Файлы:** `resources/views/auctions/partials/commercial-trading.blade.php`,
 `tests/Feature/CommercialHiddenResultsTest.php` (+2 теста). Прогон 6/6 ✓, ассеты не изменились.
+
+---
+
+## 2026-07-31 — fix #232 (реальный корень): HTML5 step-валидация блокировала подачу предложения
+
+Долгоиграющий баг «не получается сделать первую ставку» в коммерческом аукционе. Сервер,
+форма, `action` и `wouldBeat` были корректны — воспроизвести серверными тестами не удавалось.
+
+**Найдено реальным браузером** (Playwright + системный Chrome против test.bizzio.ru, логин
+участником): `form.checkValidity() = false`. Поле «Ваш срок» — `<input type="number" min="1"
+:step="steps.d">`, дефолт `d = max_deadline`. При `min=1` база шага нечётная, а `max_deadline`
+чётный (30/90/100) + чётный `step_deadline` → значение не кратно шагу → HTML5 constraint
+validation. `requestSubmit()`/клик по кнопке молча блокируются (submit-событие не диспатчится),
+пользователь видит «ничего не происходит». Ручной `fetch` POST на `/offers` при этом проходил —
+подтверждая, что бэкенд исправен.
+
+**Фикс:** в `commercial-trading.blade.php` у видимых number/range полей срок/аванс HTML-атрибут
+`step` сделан мягким — срок `step="1"` (любое целое), аванс `step="any"`. Кнопки −/+ по-прежнему
+шагают организаторским шагом через `stepDeadline()`/`stepAdvance()` (Alpine). Диапазон min/max
+сохранён; сервер валидирует значения как раньше.
+
+**Файлы:** `resources/views/auctions/partials/commercial-trading.blade.php`,
+`tests/Feature/CommercialHiddenResultsTest.php` (регресс `test_offer_form_inputs_do_not_use_hard_step_binding`).
+Прогон CommercialHiddenResultsTest 7/7. Диагностика — через реальный браузер (задел под #238).

--- a/resources/views/auctions/partials/commercial-trading.blade.php
+++ b/resources/views/auctions/partials/commercial-trading.blade.php
@@ -119,12 +119,15 @@
                             <div class="flex items-stretch gap-2">
                                 <button type="button" @click="stepDeadline(-1)" aria-label="Уменьшить срок"
                                         class="flex-none w-12 h-11 rounded-md border border-gray-300 bg-gray-50 text-3xl leading-none text-gray-700 hover:bg-gray-100 select-none">−</button>
-                                <input type="number" x-model.number="d" @input="recalc()" min="1" :max="maxDeadline" :step="steps.d"
+                                {{-- #232 step="1" (любое целое), а НЕ организаторский шаг: иначе дефолт срока (=max_deadline)
+                                     мог не совпасть с шагом при базе min=1 и HTML5-валидация молча блокировала сабмит формы.
+                                     Кнопки −/+ шагают организаторским шагом через stepDeadline(). --}}
+                                <input type="number" x-model.number="d" @input="recalc()" min="1" :max="maxDeadline" step="1"
                                        class="ca-no-spin flex-1 w-full text-center rounded-md border-gray-300 shadow-sm text-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <button type="button" @click="stepDeadline(1)" aria-label="Увеличить срок"
                                         class="flex-none w-12 h-11 rounded-md border border-gray-300 bg-gray-50 text-3xl leading-none text-gray-700 hover:bg-gray-100 select-none">+</button>
                             </div>
-                            <input type="range" x-model.number="d" @input="recalc()" min="1" :max="maxDeadline" :step="steps.d" class="w-full mt-2">
+                            <input type="range" x-model.number="d" @input="recalc()" min="1" :max="maxDeadline" step="1" class="w-full mt-2">
                             <p class="text-xs text-gray-400">Допустимо: 1…<span x-text="maxDeadline"></span> дн.</p>
                         </div>
 
@@ -139,12 +142,14 @@
                             <div class="flex items-stretch gap-2">
                                 <button type="button" @click="stepAdvance(-1)" aria-label="Уменьшить аванс"
                                         class="flex-none w-12 h-11 rounded-md border border-gray-300 bg-gray-50 text-3xl leading-none text-gray-700 hover:bg-gray-100 select-none">−</button>
-                                <input type="number" x-model.number="a" @input="recalc()" min="0" :max="maxAdvance" :step="steps.a"
+                                {{-- #232 step="any": организаторский шаг аванса мог не совпасть с дефолтом/max при базе
+                                     min=0 → HTML5-валидация блокировала сабмит. Кнопки −/+ шагают через stepAdvance(). --}}
+                                <input type="number" x-model.number="a" @input="recalc()" min="0" :max="maxAdvance" step="any"
                                        class="ca-no-spin flex-1 w-full text-center rounded-md border-gray-300 shadow-sm text-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <button type="button" @click="stepAdvance(1)" aria-label="Увеличить аванс"
                                         class="flex-none w-12 h-11 rounded-md border border-gray-300 bg-gray-50 text-3xl leading-none text-gray-700 hover:bg-gray-100 select-none">+</button>
                             </div>
-                            <input type="range" x-model.number="a" @input="recalc()" min="0" :max="maxAdvance" :step="steps.a" class="w-full mt-2">
+                            <input type="range" x-model.number="a" @input="recalc()" min="0" :max="maxAdvance" step="any" class="w-full mt-2">
                             <p class="text-xs text-gray-400">Допустимо: 0…<span x-text="maxAdvance"></span>%</p>
                         </div>
 

--- a/tests/Feature/CommercialHiddenResultsTest.php
+++ b/tests/Feature/CommercialHiddenResultsTest.php
@@ -169,6 +169,24 @@ class CommercialHiddenResultsTest extends TestCase
             ->assertDontSee('Вы организатор этой процедуры');
     }
 
+    public function test_offer_form_inputs_do_not_use_hard_step_binding(): void
+    {
+        // #232 Регресс: у полей срок/аванс НЕ должно быть жёсткого организаторского шага
+        // как HTML-атрибута step — иначе дефолт (=max_deadline/max_advance) мог не совпасть
+        // с шагом при базе min и HTML5-валидация молча блокировала сабмит формы предложения.
+        // Берём max_deadline, кратный шагу «неудобно» (чётный max при чётном шаге и базе min=1).
+        $auction = $this->hiddenTradingAuction();
+        $auction->update(['max_deadline' => 30, 'step_deadline' => 2, 'max_advance' => 100, 'step_advance' => 10]);
+        [$user] = $this->participant($auction);
+
+        $resp = $this->actingAs($user)->get(route('auctions.show', $auction))->assertOk();
+        // Жёсткого биндинга шага быть не должно.
+        $resp->assertDontSee(':step="steps.d"', false);
+        $resp->assertDontSee(':step="steps.a"', false);
+        // Поле срока — целочисленный шаг 1 (любое целое допустимо и сабмитится).
+        $resp->assertSee('step="1"', false);
+    }
+
     public function test_worse_offer_still_rejected_with_hidden_results(): void
     {
         $auction = $this->hiddenTradingAuction();


### PR DESCRIPTION
## Summary

Настоящий корень бага «не получается сделать первую ставку» в коммерческом аукционе (этап 2). Найден **реальным браузером** (Playwright + Chrome против test.bizzio.ru).

Поле «Ваш срок» — `<input type="number" min="1" :step="steps.d">`, дефолт `d = max_deadline`. При `min=1` (нечётная база шага) и чётном `max_deadline` + чётном `step_deadline` значение не кратно шагу → **HTML5 constraint validation** → браузер молча блокирует submit (`requestSubmit()` не диспатчит событие, клик по кнопке «ничего не делает»). `form.checkValidity()=false`, сообщение «Ближайшее допустимое значение: 29». Бэкенд исправен — ручной `fetch` POST на `/offers` проходит.

**Фикс:** у видимых number/range полей срок/аванс HTML-атрибут `step` смягчён — срок `step="1"`, аванс `step="any"`. Кнопки −/+ по-прежнему шагают организаторским шагом (Alpine). Диапазон min/max и серверная валидация не менялись.

## Test plan
- [x] `CommercialHiddenResultsTest` 7/7, вкл. регресс `test_offer_form_inputs_do_not_use_hard_step_binding`
- [x] Диагностика в реальном браузере: `checkValidity()` до фикса = false (поле срока), после — форма сабмитится
- [x] Ассеты не изменились
- [ ] После деплоя на тест — повторный Playwright-прогон end-to-end (подача предложения)

Relates to #232