### PR TITLE
hotfix(commercial): планировщик отменял коммерческий этап 2 (регресс #222)

### DIFF
--- a/app/Console/Commands/UpdateAuctionStatuses.php
+++ b/app/Console/Commands/UpdateAuctionStatuses.php
@@ -2,9 +2,7 @@
 
 namespace App\Console\Commands;
 
-use App\Jobs\CloseAuctionJob;
-use App\Models\Auction;
-use Carbon\Carbon;
+use App\Jobs\UpdateAuctionStatuses as UpdateAuctionStatusesJob;
 use Illuminate\Console\Command;
 
 class UpdateAuctionStatuses extends Command
@@ -13,71 +11,21 @@ class UpdateAuctionStatuses extends Command
 
     protected $description = 'Обновить статусы аукционов на основе текущего времени';
 
+    /**
+     * Делегируем всю логику единственной реализации — джобе UpdateAuctionStatuses.
+     *
+     * #222 Раньше команда дублировала логику джобы и разошлась с ней: её блок 1 не исключал
+     * коммерческие аукционы и по 0 initialBids отменял коммерческий этап 2 при старте торгов.
+     * Чтобы фиксы больше не расходились между планировщиком (команда) и джобой — держим одну
+     * реализацию в App\Jobs\UpdateAuctionStatuses, а команда лишь вызывает её.
+     */
     public function handle(): int
     {
-        $this->info('🔄 Начинаю обновление статусов аукционов...');
+        $this->info('🔄 Обновление статусов аукционов…');
 
-        $now = Carbon::now();
-        $this->line("Текущее время: {$now->toDateTimeString()}");
+        (new UpdateAuctionStatusesJob)->handle();
 
-        // 1. Активные аукционы → Торги
-        $expiredActive = Auction::where('status', 'active')
-            ->where('end_date', '<=', $now)
-            ->where('trading_start', '<=', $now)
-            ->get();
-
-        $this->line("\n📋 Найдено истёкших активных аукционов: {$expiredActive->count()}");
-
-        foreach ($expiredActive as $auction) {
-            $bidsCount = $auction->initialBids()->count();
-
-            $this->line("  • {$auction->number}: заявок={$bidsCount}");
-
-            if ($bidsCount > 0) {
-                $auction->update(['status' => 'trading']);
-
-                // Генерируем анонимные коды
-                foreach ($auction->initialBids as $bid) {
-                    if (! $bid->anonymous_code) {
-                        $code = Auction::generateAnonymousCode();
-                        $bid->update(['anonymous_code' => $code]);
-                    }
-                }
-
-                $this->info("    ✅ Переведён в 'trading'");
-            } else {
-                $auction->update(['status' => 'cancelled']);
-                $this->warn('    ❌ Отменён (нет заявок)');
-            }
-        }
-
-        // 2. Торги → Завершён
-        $expiredTrading = Auction::where('status', 'trading')
-            ->whereNotNull('last_bid_at')
-            ->where('last_bid_at', '<=', $now->copy()->subMinutes(20))
-            ->get();
-
-        $this->line("\n🏁 Найдено завершённых торгов: {$expiredTrading->count()}");
-
-        foreach ($expiredTrading as $auction) {
-            CloseAuctionJob::dispatch($auction->id);
-            $this->info("  📋 {$auction->number} — запланировано закрытие");
-        }
-
-        // 3. Торги без ставок → Отменён
-        $tradingWithoutBids = Auction::where('status', 'trading')
-            ->whereNull('last_bid_at')
-            ->where('trading_start', '<=', $now->copy()->subHours(24))
-            ->get();
-
-        $this->line("\n⏰ Торгов без ставок 24ч: {$tradingWithoutBids->count()}");
-
-        foreach ($tradingWithoutBids as $auction) {
-            $auction->update(['status' => 'cancelled']);
-            $this->warn("  ❌ {$auction->number} отменён (нет ставок)");
-        }
-
-        $this->info("\n✅ Обновление завершено!");
+        $this->info('✅ Готово (см. лог для деталей).');
 
         return 0;
     }

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -2364,3 +2364,22 @@ validation. `requestSubmit()`/клик по кнопке молча блокир
 `resources/views/auctions/partials/commercial-trading.blade.php`,
 `tests/Feature/CommercialAuctionTest.php`, `tests/Feature/CommercialHiddenResultsTest.php`.
 Прогон: CommercialAuctionTest+CommercialHiddenResultsTest+AuctionTest 82/82. Pint чист.
+
+---
+
+## 2026-07-31 — hotfix: планировщик отменял коммерческий этап 2 (регресс #222)
+
+Регресс предыдущего фикса #222. Существуют ДВЕ реализации обновления статусов:
+`App\Jobs\UpdateAuctionStatuses` (джоба) и `App\Console\Commands\UpdateAuctionStatuses`
+(команда `auctions:update-statuses`, её гоняет планировщик каждую минуту). Фикс #222 добавил
+обработку коммерческого 'active'→'trading' только в ДЖОБУ. Команда же дублировала логику и
+в блоке 1 НЕ исключала коммерческие: при наступлении trading_start видела 'active' + 0
+initialBids (у этапа 2 их нет — участники с этапа 1) и ОТМЕНЯЛА аукцион. Симптом (Mike):
+«этап 2 не стартует, аукцион переходит в завершён спустя минуту, окно торгов не открывается».
+
+Фикс: команда `auctions:update-statuses` теперь делегирует всю логику единственной реализации —
+`App\Jobs\UpdateAuctionStatuses` (устранено дублирование, фиксы больше не разойдутся). Джоба
+дополнительно формирует протокол при отмене — команда раньше этого не делала.
+
+**Файлы:** `app/Console/Commands/UpdateAuctionStatuses.php`, `tests/Feature/CommercialAuctionTest.php`
+(регресс `test_scheduler_command_starts_commercial_stage2_and_does_not_cancel_it`). Тесты 23/23.

--- a/tests/Feature/CommercialAuctionTest.php
+++ b/tests/Feature/CommercialAuctionTest.php
@@ -301,6 +301,21 @@ class CommercialAuctionTest extends TestCase
         $this->assertSame('trading', $rfq->fresh()->linkedAuction->status);
     }
 
+    public function test_scheduler_command_starts_commercial_stage2_and_does_not_cancel_it(): void
+    {
+        // #222 Регресс: планировщик гоняет КОМАНДУ auctions:update-statuses. Она не должна
+        // отменять коммерческий этап 2 из-за отсутствия initialBids (у этапа 2 их нет) —
+        // при наступлении trading_start торги должны СТАРТОВАТЬ.
+        $auction = $this->tradingCommercialAuction([
+            'status' => 'active',
+            'trading_start' => now()->subMinute(),
+        ]);
+
+        $this->artisan('auctions:update-statuses')->assertExitCode(0);
+
+        $this->assertSame('trading', $auction->fresh()->status, 'Коммерческий этап 2 должен стартовать, а не отмениться');
+    }
+
     public function test_closing_commercial_rfq_without_bids_does_not_launch(): void
     {
         $rfq = $this->closeableCommercialRfq([]);


### PR DESCRIPTION
Регресс #222. Планировщик гоняет КОМАНДУ auctions:update-statuses (не джобу). Команда дублировала логику и не исключала коммерческие — при trading_start видела 'active'+0 initialBids и ОТМЕНЯЛА этап 2. Симптом (Mike): «этап 2 не стартует, завершается спустя минуту, окно торгов не открывается». Фикс: команда делегирует в App\Jobs\UpdateAuctionStatuses (одна реализация). Тесты 23/23 (+регресс). Relates to #222