### PR TITLE
fix: ложный лимит при перезагрузке файла + авто-открытие торгов этапа 2

### DIFF
--- a/app/Http/Controllers/AuctionController.php
+++ b/app/Http/Controllers/AuctionController.php
@@ -133,6 +133,14 @@ class AuctionController extends Controller
     {
         $this->authorize('view', $auction);
 
+        // #222 Ленивый старт торгов этапа 2: если назначенное время уже наступило, а планировщик
+        // (раз в минуту) ещё не перевёл аукцион — стартуем торги прямо сейчас, при заходе на страницу.
+        // Так окно торгов открывается ровно вовремя, без задержки до минутного тика.
+        if ($auction->isCommercial() && $auction->status === 'active' && $auction->trading_start->isPast()) {
+            $auction->update(['status' => 'trading']);
+            $auction->refresh();
+        }
+
         $auction->load([
             'company.industry',
             'creator.badges',

--- a/app/Http/Controllers/TempUploadController.php
+++ b/app/Http/Controllers/TempUploadController.php
@@ -110,7 +110,14 @@ class TempUploadController extends Controller
         $temp = ProcurementDocuments::tempFiles();
 
         // Проверка суммарного объёма (≤ 20 МБ) с учётом уже загруженных temp-файлов.
-        if (ProcurementDocuments::tempTotalSize() + $file->getSize() > ProcurementDocuments::MAX_TOTAL_BYTES) {
+        // Одиночная коллекция (Извещение/ТЗ/Проект договора) при повторной загрузке ЗАМЕНЯЕТ
+        // предыдущий файл — поэтому исключаем его размер из суммы, иначе перезагрузка того же
+        // файла ложно упиралась в лимит («Общий объём…»), и приходилось удалять и прикладывать заново.
+        $replacedSize = ($collection !== 'other_documents' && ! empty($temp[$collection]['size']))
+            ? (int) $temp[$collection]['size']
+            : 0;
+
+        if (ProcurementDocuments::tempTotalSize() - $replacedSize + $file->getSize() > ProcurementDocuments::MAX_TOTAL_BYTES) {
             return response()->json([
                 'success' => false,
                 'message' => 'Общий объём конкурсной документации не должен превышать 20 МБ.',

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -2383,3 +2383,25 @@ initialBids (у этапа 2 их нет — участники с этапа 1)
 
 **Файлы:** `app/Console/Commands/UpdateAuctionStatuses.php`, `tests/Feature/CommercialAuctionTest.php`
 (регресс `test_scheduler_command_starts_commercial_stage2_and_does_not_cancel_it`). Тесты 23/23.
+
+---
+
+## 2026-08-01 — fix: ложный лимит при перезагрузке файла + авто-открытие торгов этапа 2
+
+Два бага (Mike, аукцион 85).
+
+**Файловая ошибка «Общий объём…» при повторной загрузке.** В `TempUploadController::storeProcurement`
+проверка суммарного объёма учитывала прежний temp-файл ОДИНОЧНОЙ коллекции (Извещение/ТЗ/Проект
+договора), который тут же заменяется. Перезагрузка того же файла (>10 МБ) ложно упиралась в 20 МБ —
+приходилось удалять и прикладывать заново. Фикс: при замене одиночной коллекции исключаем её прежний
+размер из суммы. «Прочие файлы» (накапливаются) — кумулятивный лимит сохранён.
+
+**Торги этапа 2 открывались с задержкой и требовали ручного рефреша.** Планировщик переводит
+'active'→'trading' раз в минуту, а страница ожидания не обновлялась сама. Фикс: (1) ленивый переход в
+`AuctionController::show()` — если `trading_start` уже наступил, стартуем торги прямо при заходе; (2) на
+странице ожидания — авто-перезагрузка при наступлении времени начала (открывается окно торгов без
+ручного рефреша).
+
+**Файлы:** `app/Http/Controllers/TempUploadController.php`, `app/Http/Controllers/AuctionController.php`,
+`resources/views/auctions/show.blade.php`, `tests/Feature/ProcurementTempUploadSizeTest.php` (новый, 3 теста).
+Прогон: ProcurementTempUploadSizeTest 3/3, AuctionTest+CommercialAuctionTest 75/75. Pint чист, ассеты без изменений.

--- a/resources/views/auctions/show.blade.php
+++ b/resources/views/auctions/show.blade.php
@@ -163,6 +163,21 @@
                             @if($auction->status === 'active' && $auction->isCommercial() && $auction->trading_start->isFuture())
                                 @include('partials.countdown', ['target' => $auction->trading_start, 'label' => 'До начала торгов', 'color' => 'bg-blue-100 text-blue-800'])
                             @endif
+
+                            {{-- #222 Авто-открытие торгов: при наступлении времени начала перезагружаем страницу
+                                 (в show() сработает ленивый переход в 'trading' и откроется окно торгов) — без ручного рефреша. --}}
+                            @if($auction->status === 'active' && $auction->isCommercial())
+                                <div x-data="{
+                                        target: new Date('{{ $auction->trading_start->toIso8601String() }}').getTime(),
+                                        init() {
+                                            const tick = () => {
+                                                if (Date.now() >= this.target + 2000) { window.location.reload(); return; }
+                                                setTimeout(tick, 1000);
+                                            };
+                                            tick();
+                                        }
+                                     }" x-init="init()"></div>
+                            @endif
                             
                             @if($auction->status === 'trading' && $auction->last_bid_at)
                                 <span class="text-xs text-gray-500">

--- a/tests/Feature/ProcurementTempUploadSizeTest.php
+++ b/tests/Feature/ProcurementTempUploadSizeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+/**
+ * #185 Лимит суммарного объёма конкурсной документации при temp-загрузке.
+ */
+class ProcurementTempUploadSizeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create(['email_verified_at' => now()]);
+        Storage::fake('local');
+    }
+
+    private function upload(string $collection, int $kilobytes)
+    {
+        $pdf = UploadedFile::fake()->create('doc.pdf', $kilobytes, 'application/pdf');
+
+        return $this->actingAs($this->user)->postJson(route('procurement-temp-upload.store'), [
+            'file' => $pdf,
+            'collection' => $collection,
+        ]);
+    }
+
+    public function test_reupload_single_collection_replaces_and_does_not_double_count(): void
+    {
+        // Повторная загрузка одиночной коллекции ЗАМЕНЯЕТ файл — прежний размер не должен
+        // учитываться в сумме (иначе перезагрузка того же ~12 МБ файла ложно упиралась в 20 МБ).
+        $this->upload('technical_specification', 12000)->assertOk()->assertJsonPath('success', true);
+        $this->upload('technical_specification', 12000)->assertOk()->assertJsonPath('success', true);
+    }
+
+    public function test_other_documents_still_enforce_cumulative_limit(): void
+    {
+        // «Прочие файлы» накапливаются — суммарный лимит 20 МБ по-прежнему действует.
+        $this->upload('other_documents', 12000)->assertOk()->assertJsonPath('success', true);
+        $this->upload('other_documents', 12000)
+            ->assertStatus(422)
+            ->assertJsonPath('success', false);
+    }
+
+    public function test_total_across_different_single_collections_still_limited(): void
+    {
+        // Разные одиночные коллекции суммируются: 12 + 12 > 20 → второй отклоняется.
+        $this->upload('technical_specification', 12000)->assertOk()->assertJsonPath('success', true);
+        $this->upload('notice', 12000)
+            ->assertStatus(422)
+            ->assertJsonPath('success', false);
+    }
+}


### PR DESCRIPTION
## Summary
Два бага (аукцион 85).

**Файл «Общий объём…» при перезагрузке.** `storeProcurement` учитывал прежний temp-файл одиночной коллекции (ТЗ/Извещение/Договор), который тут же заменяется → перезагрузка того же >10МБ файла ложно упиралась в 20МБ (отсюда «удалить и приложить заново»). Исключаем заменяемый размер; «прочие» — кумулятивный лимит сохранён.

**Авто-открытие торгов этапа 2.** Планировщик флипает `active→trading` раз в минуту, страница ожидания не обновлялась сама (Mike: открылось с задержкой + ручной рефреш). Фикс: ленивый переход в `show()` (старт при заходе, если `trading_start` наступил) + авто-перезагрузка страницы ожидания в момент начала.

## Test plan
- [x] `ProcurementTempUploadSizeTest` 3/3 (перезагрузка одиночной не двоится; «прочие» и разные коллекции — лимит сохранён)
- [x] AuctionTest+CommercialAuctionTest 75/75
- [x] Pint чист, ассеты не изменились

Relates to #185, #222