### PR TITLE
fix(commercial): аванс показывал «кучу цифр» после запятой

### DIFF
--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -2405,3 +2405,18 @@ initialBids (у этапа 2 их нет — участники с этапа 1)
 **Файлы:** `app/Http/Controllers/TempUploadController.php`, `app/Http/Controllers/AuctionController.php`,
 `resources/views/auctions/show.blade.php`, `tests/Feature/ProcurementTempUploadSizeTest.php` (новый, 3 теста).
 Прогон: ProcurementTempUploadSizeTest 3/3, AuctionTest+CommercialAuctionTest 75/75. Pint чист, ассеты без изменений.
+
+---
+
+## 2026-08-01 — fix: аванс в торгах показывал «кучу цифр» после запятой
+
+Mike: значение аванса выводилось с длинным хвостом дробей. Причина — ранее для поля аванса
+поставили `step="any"` (чтобы обойти HTML5-валидацию), и слайдер при перетаскивании давал
+непрерывный float (напр. 43.2857142857 %). Фикс: слайдер/поле аванса → `step="0.01"` (2 знака;
+max_advance — decimal(5,2), кратен 0.01, поэтому баг валидации не возвращается) + округление
+вывода аванса в панели лидера и истории через round2(). Кнопки −/+ по-прежнему шагают
+организаторским шагом. Сохранённые значения и так были decimal(5,2) — правка чисто в живом UI.
+
+**Файлы:** `resources/views/auctions/partials/commercial-trading.blade.php`,
+`tests/Feature/CommercialHiddenResultsTest.php` (тест дополнен: нет `step="any"`, есть `step="0.01"`).
+Прогон CommercialHiddenResultsTest 8/8. Ассеты без изменений.

--- a/resources/views/auctions/partials/commercial-trading.blade.php
+++ b/resources/views/auctions/partials/commercial-trading.blade.php
@@ -58,7 +58,7 @@
                                 <span x-show="best.is_mine" class="text-emerald-600">(ваше)</span></p>
                             <p>Цена: <span class="font-semibold" x-text="fmt(best.price)"></span> <span x-text="currency"></span></p>
                             <p>Срок: <span class="font-semibold" x-text="best.deadline"></span> дн. ·
-                               Аванс: <span class="font-semibold" x-text="best.advance"></span>%</p>
+                               Аванс: <span class="font-semibold" x-text="round2(best.advance)"></span>%</p>
                             <p>Рейтинг: <span class="font-semibold" x-text="round2(best.total_score)"></span> ·
                                <span x-text="best.time"></span></p>
                         </div>
@@ -142,14 +142,14 @@
                             <div class="flex items-stretch gap-2">
                                 <button type="button" @click="stepAdvance(-1)" aria-label="Уменьшить аванс"
                                         class="flex-none w-12 h-11 rounded-md border border-gray-300 bg-gray-50 text-3xl leading-none text-gray-700 hover:bg-gray-100 select-none">−</button>
-                                {{-- #232 step="any": организаторский шаг аванса мог не совпасть с дефолтом/max при базе
-                                     min=0 → HTML5-валидация блокировала сабмит. Кнопки −/+ шагают через stepAdvance(). --}}
-                                <input type="number" x-model.number="a" @input="recalc()" min="0" :max="maxAdvance" step="any"
+                                {{-- #232/аванс: step="0.01" — 2 знака после запятой (без «кучи цифр» от слайдера)
+                                     и без бага валидации: max_advance — decimal(5,2), кратен 0.01. Кнопки −/+ шагают через stepAdvance(). --}}
+                                <input type="number" x-model.number="a" @input="a = round2(a); recalc()" min="0" :max="maxAdvance" step="0.01"
                                        class="ca-no-spin flex-1 w-full text-center rounded-md border-gray-300 shadow-sm text-sm focus:border-emerald-500 focus:ring-emerald-500">
                                 <button type="button" @click="stepAdvance(1)" aria-label="Увеличить аванс"
                                         class="flex-none w-12 h-11 rounded-md border border-gray-300 bg-gray-50 text-3xl leading-none text-gray-700 hover:bg-gray-100 select-none">+</button>
                             </div>
-                            <input type="range" x-model.number="a" @input="recalc()" min="0" :max="maxAdvance" step="any" class="w-full mt-2">
+                            <input type="range" x-model.number="a" @input="a = round2(a); recalc()" min="0" :max="maxAdvance" step="0.01" class="w-full mt-2">
                             <p class="text-xs text-gray-400">Допустимо: 0…<span x-text="maxAdvance"></span>%</p>
                         </div>
 
@@ -210,7 +210,7 @@
                                     <td class="px-2 py-2 font-mono" x-text="o.anonymous_code"></td>
                                     <td class="px-2 py-2 text-right" x-text="fmt(o.price)"></td>
                                     <td class="px-2 py-2 text-right" x-text="o.deadline"></td>
-                                    <td class="px-2 py-2 text-right" x-text="o.advance + '%'"></td>
+                                    <td class="px-2 py-2 text-right" x-text="round2(o.advance) + '%'"></td>
                                     <td class="px-2 py-2 text-right" x-text="round2(o.total_score)"></td>
                                     <td class="px-2 py-2 text-right text-gray-400" x-text="o.time"></td>
                                 </tr>

--- a/tests/Feature/CommercialHiddenResultsTest.php
+++ b/tests/Feature/CommercialHiddenResultsTest.php
@@ -202,8 +202,11 @@ class CommercialHiddenResultsTest extends TestCase
         // Жёсткого биндинга шага быть не должно.
         $resp->assertDontSee(':step="steps.d"', false);
         $resp->assertDontSee(':step="steps.a"', false);
-        // Поле срока — целочисленный шаг 1 (любое целое допустимо и сабмитится).
+        // step="any" убран у аванса — иначе слайдер давал «кучу цифр» после запятой.
+        $resp->assertDontSee('step="any"', false);
+        // Поле срока — целочисленный шаг 1; поле аванса — 0.01 (2 знака, без биллиардных дробей).
         $resp->assertSee('step="1"', false);
+        $resp->assertSee('step="0.01"', false);
     }
 
     public function test_worse_offer_still_rejected_with_hidden_results(): void


### PR DESCRIPTION
Аванс выводился с длинным дробным хвостом. Причина — step="any" на слайдере (непрерывный float при перетаскивании). Фикс: step="0.01" (2 знака; max_advance decimal(5,2) кратен 0.01 → баг валидации не возвращается) + округление вывода через round2(). CommercialHiddenResultsTest 8/8.