### PR TITLE
feat(commercial-auction): #237 результаты скрыты по умолчанию, галочка убрана

### DIFF
--- a/app/Http/Controllers/AuctionController.php
+++ b/app/Http/Controllers/AuctionController.php
@@ -207,12 +207,11 @@ class AuctionController extends Controller
         $stepRange = $auction->getStepRange();
 
         // #115: Определяем, может ли пользователь видеть результаты
+        // #237 Участником считаем и приглашённую компанию без ставок: на этапе 2 коммерческого
+        // аукциона участники приходят с этапа 1 приглашениями, а торговать могли не все.
         $canSeeResults = true;
-        if ($auction->is_results_hidden && in_array($auction->status, ['closed', 'cancelled'])) {
-            $isManager = auth()->check() && $auction->canManage(auth()->user());
-            $isParticipant = auth()->check() && $auction->bids->pluck('company_id')
-                ->intersect($userCompanies->pluck('id'))->isNotEmpty();
-            $canSeeResults = $isManager || $isParticipant;
+        if (in_array($auction->status, ['closed', 'cancelled'])) {
+            $canSeeResults = ! $auction->resultsHiddenFor(auth()->user());
         }
 
         // #119: При торгах показываем только компанию, от которой подана заявка текущим пользователем

--- a/app/Http/Controllers/RfqController.php
+++ b/app/Http/Controllers/RfqController.php
@@ -107,7 +107,9 @@ class RfqController extends Controller
                 'weight_deadline' => $request->weight_deadline,
                 'weight_advance' => $request->weight_advance,
                 'status' => $request->status ?? 'draft', // ✅ ИСПОЛЬЗУЕМ СТАТУС ИЗ ФОРМЫ
-                'is_results_hidden' => $request->boolean('is_results_hidden'),
+                // #237 У коммерческого аукциона результаты скрыты всегда (галочки в форме нет):
+                // их видят только организатор и участники процедуры.
+                'is_results_hidden' => $procedure === Rfq::PROCEDURE_COMMERCIAL || $request->boolean('is_results_hidden'),
             ];
 
             // #179 Параметры этапа 2 для коммерческого аукциона.

--- a/app/Http/Requests/UpdateRfqRequest.php
+++ b/app/Http/Requests/UpdateRfqRequest.php
@@ -64,8 +64,9 @@ class UpdateRfqRequest extends FormRequest
      */
     protected function prepareForValidation(): void
     {
+        // #237 У коммерческого аукциона результаты скрыты всегда — снять флаг нельзя.
         $this->merge([
-            'is_results_hidden' => $this->boolean('is_results_hidden'),
+            'is_results_hidden' => $this->route('rfq')?->isCommercial() || $this->boolean('is_results_hidden'),
         ]);
     }
 

--- a/app/Services/CommercialAuctionLauncherService.php
+++ b/app/Services/CommercialAuctionLauncherService.php
@@ -74,7 +74,8 @@ class CommercialAuctionLauncherService
                 // #210 Референсы нормировки (100% шкалы) задаёт организатор на этапе 1 — переносим в аукцион.
                 'max_deadline' => $rfq->max_deadline,
                 'max_advance' => $rfq->max_advance,
-                'is_results_hidden' => $rfq->is_results_hidden,
+                // #237 Ход и итоги коммерческих торгов видны только организатору и участникам.
+                'is_results_hidden' => true,
                 // #222 До trading_start аукцион ждёт в статусе 'active' (участники известны, приёма
                 // заявок нет). UpdateAuctionStatuses переведёт его в 'trading' в назначенное время.
                 'status' => $startsTradingNow ? 'trading' : 'active',

--- a/database/migrations/2026_08_03_120000_hide_results_for_commercial_procedures.php
+++ b/database/migrations/2026_08_03_120000_hide_results_for_commercial_procedures.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * #237 У коммерческого аукциона результаты скрыты всегда (галочки в форме больше нет).
+ * Приводим ранее созданные процедуры к этому правилу.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('rfqs')->where('procedure', 'commercial')->update(['is_results_hidden' => true]);
+        DB::table('auctions')->where('procedure', 'commercial')->update(['is_results_hidden' => true]);
+    }
+
+    public function down(): void
+    {
+        // Обратной операции нет: прежнее значение флага не сохранялось.
+    }
+};

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -2454,3 +2454,33 @@ read-only — смена организатора ломала бы пригла
 попали классы из скомпилированных вью прошлых версий. После `artisan view:clear` сборка вернулась
 к исходному хэшу. Вывод: перед проверкой Assets freshness всегда чистим кэш вью, иначе
 закоммитим ложный дифф `public/build`.
+
+---
+
+## 2026-08-03 — feat #237: результаты коммерческого аукциона скрыты по умолчанию
+
+**Задача:** у коммерческих аукционов результаты должны быть скрыты всегда — их видят только
+администраторы/модераторы компании-организатора и компаний-участников. Галочку «Скрыть результаты»
+из формы убрать.
+
+**Сделано:**
+- `RfqController::store` — при `procedure=commercial` флаг `is_results_hidden` ставится принудительно.
+- `UpdateRfqRequest::prepareForValidation` — у коммерческой процедуры флаг нельзя снять даже
+  подделанным запросом (галочки в форме нет, поэтому отсутствие поля не должно раскрывать торги).
+- `CommercialAuctionLauncherService` — этап 2 создаётся со скрытыми результатами всегда (раньше
+  копировал флаг с этапа 1).
+- Формы создания и редактирования: галочка показывается только для обычного Запроса цен, для
+  коммерческого — поясняющая строка.
+- `AuctionController::show` — проверка видимости итогов переведена на `Auction::resultsHiddenFor()`.
+  Раньше участником считался только тот, кто подал ставку; теперь — приглашённая компания. Это важно
+  для этапа 2: участники приходят с этапа 1 приглашениями, но торговать могли не все, и «молчавший»
+  участник итогов не видел.
+- Миграция `2026_08_03_120000_hide_results_for_commercial_procedures` — проставляет флаг уже
+  созданным коммерческим RFQ и аукционам.
+
+**Файлы:** `app/Http/Controllers/RfqController.php`, `app/Http/Controllers/AuctionController.php`,
+`app/Http/Requests/UpdateRfqRequest.php`, `app/Services/CommercialAuctionLauncherService.php`,
+`resources/views/rfqs/create.blade.php`, `resources/views/rfqs/edit.blade.php`,
+`database/migrations/2026_08_03_120000_hide_results_for_commercial_procedures.php`,
+`tests/Feature/CommercialHiddenResultsTest.php` (+5 тестов).
+Прогон: весь набор 347/347. Pint чист, ассеты без изменений.

--- a/resources/views/rfqs/create.blade.php
+++ b/resources/views/rfqs/create.blade.php
@@ -429,7 +429,8 @@
                     </div>
 
                     <!-- Скрытие результатов после завершения -->
-                    <div class="mb-6">
+                    {{-- #237 У коммерческого аукциона результаты скрыты всегда — выбора нет. --}}
+                    <div class="mb-6" x-show="procedure !== 'commercial'" x-cloak>
                         <label class="inline-flex items-center">
                             <input type="checkbox"
                                    name="is_results_hidden"
@@ -441,6 +442,9 @@
                                 <span class="text-gray-500">(видны только организатору и участникам)</span>
                             </span>
                         </label>
+                    </div>
+                    <div class="mb-6 text-sm text-gray-600" x-show="procedure === 'commercial'" x-cloak>
+                        Ход торгов и итоги коммерческого аукциона видны только организатору и компаниям-участникам.
                     </div>
 
                     <!-- Кнопки -->

--- a/resources/views/rfqs/edit.blade.php
+++ b/resources/views/rfqs/edit.blade.php
@@ -254,19 +254,26 @@
                     @include('partials.procurement-documents', ['model' => $rfq, 'tzRequired' => false])
 
                     <!-- Скрытие результатов после завершения -->
-                    <div class="mb-6">
-                        <label class="inline-flex items-center">
-                            <input type="checkbox"
-                                   name="is_results_hidden"
-                                   value="1"
-                                   {{ old('is_results_hidden', $rfq->is_results_hidden) ? 'checked' : '' }}
-                                   class="rounded border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
-                            <span class="ml-2 text-sm text-gray-700">
-                                Скрыть результаты после завершения
-                                <span class="text-gray-500">(видны только организатору и участникам)</span>
-                            </span>
-                        </label>
-                    </div>
+                    {{-- #237 У коммерческого аукциона результаты скрыты всегда — выбора нет. --}}
+                    @if($isCommercial)
+                        <div class="mb-6 text-sm text-gray-600">
+                            Ход торгов и итоги коммерческого аукциона видны только организатору и компаниям-участникам.
+                        </div>
+                    @else
+                        <div class="mb-6">
+                            <label class="inline-flex items-center">
+                                <input type="checkbox"
+                                       name="is_results_hidden"
+                                       value="1"
+                                       {{ old('is_results_hidden', $rfq->is_results_hidden) ? 'checked' : '' }}
+                                       class="rounded border-gray-300 text-emerald-600 shadow-sm focus:border-emerald-500 focus:ring-emerald-500">
+                                <span class="ml-2 text-sm text-gray-700">
+                                    Скрыть результаты после завершения
+                                    <span class="text-gray-500">(видны только организатору и участникам)</span>
+                                </span>
+                            </label>
+                        </div>
+                    @endif
 
                     <!-- Кнопки -->
                     <div class="flex justify-between items-center">

--- a/tests/Feature/CommercialHiddenResultsTest.php
+++ b/tests/Feature/CommercialHiddenResultsTest.php
@@ -225,4 +225,130 @@ class CommercialHiddenResultsTest extends TestCase
 
         $this->assertSame($bestBefore, $auction->fresh()->best_bid_id);
     }
+
+    // =========================================================
+    // #237 — у коммерческой процедуры результаты скрыты по умолчанию
+    // =========================================================
+
+    public function test_commercial_rfq_is_created_with_hidden_results_without_checkbox(): void
+    {
+        $this->actingAs($this->organizer)
+            ->post(route('rfqs.store'), [
+                'title' => 'КА без галочки',
+                'company_id' => $this->company->id,
+                'type' => 'open',
+                'procedure' => 'commercial',
+                'currency' => 'RUB',
+                'status' => 'draft',
+                'start_date' => now()->format('Y-m-d H:i:s'),
+                'end_date' => now()->addDay()->format('Y-m-d H:i:s'),
+                'weight_price' => 70, 'weight_deadline' => 20, 'weight_advance' => 10,
+                'trading_start' => now()->addDay()->addHour()->format('Y-m-d H:i:s'),
+                'step_price' => 0.5, 'step_deadline' => 1, 'step_advance' => 5,
+                'max_deadline' => 90, 'max_advance' => 100,
+                'technical_specification' => \Illuminate\Http\UploadedFile::fake()->createWithContent('tz.pdf', '%PDF-1.4 test'),
+                // Галочка НЕ передаётся — в форме коммерческого аукциона её нет.
+            ])
+            ->assertRedirect();
+
+        $rfq = \App\Models\Rfq::where('title', 'КА без галочки')->firstOrFail();
+
+        $this->assertTrue($rfq->is_results_hidden);
+    }
+
+    public function test_standard_rfq_keeps_checkbox_behaviour(): void
+    {
+        $this->actingAs($this->organizer)
+            ->post(route('rfqs.store'), [
+                'title' => 'Обычный запрос цен',
+                'company_id' => $this->company->id,
+                'type' => 'open',
+                'procedure' => 'standard',
+                'currency' => 'RUB',
+                'status' => 'draft',
+                'start_date' => now()->format('Y-m-d H:i:s'),
+                'end_date' => now()->addDay()->format('Y-m-d H:i:s'),
+                'weight_price' => 50, 'weight_deadline' => 30, 'weight_advance' => 20,
+                'technical_specification' => \Illuminate\Http\UploadedFile::fake()->createWithContent('tz.pdf', '%PDF-1.4 test'),
+            ])
+            ->assertRedirect();
+
+        $this->assertFalse(\App\Models\Rfq::where('title', 'Обычный запрос цен')->firstOrFail()->is_results_hidden);
+    }
+
+    public function test_commercial_draft_edit_cannot_unhide_results(): void
+    {
+        $rfq = \App\Models\Rfq::create([
+            'number' => \App\Models\Rfq::generateNumber(),
+            'title' => 'КА черновик',
+            'company_id' => $this->company->id,
+            'created_by' => $this->organizer->id,
+            'type' => 'open',
+            'procedure' => \App\Models\Rfq::PROCEDURE_COMMERCIAL,
+            'currency' => 'RUB',
+            'start_date' => now()->addDay(),
+            'end_date' => now()->addDays(2),
+            'trading_start' => now()->addDays(2)->addHour(),
+            'weight_price' => 70, 'weight_deadline' => 20, 'weight_advance' => 10,
+            'step_price' => 0.5, 'step_deadline' => 1, 'step_advance' => 5,
+            'max_deadline' => 90, 'max_advance' => 100,
+            'is_results_hidden' => true,
+            'status' => 'draft',
+        ]);
+
+        // Форма коммерческого аукциона галочку не выводит...
+        $this->actingAs($this->organizer)
+            ->get(route('rfqs.edit', $rfq))
+            ->assertOk()
+            ->assertDontSee('name="is_results_hidden"', false);
+
+        // ...и подделанный запрос без неё флаг не снимает.
+        $this->actingAs($this->organizer)
+            ->put(route('rfqs.update', $rfq), ['title' => 'КА черновик'])
+            ->assertRedirect();
+
+        $this->assertTrue($rfq->fresh()->is_results_hidden);
+    }
+
+    public function test_closed_commercial_auction_hides_results_from_outsider_but_not_participant(): void
+    {
+        $auction = $this->hiddenTradingAuction();
+        $auction->update(['type' => 'open']); // чтобы посторонний мог открыть страницу
+        [$leadUser, $leadCompany] = $this->participant($auction);
+        $this->seedLeader($auction, $leadCompany, $leadUser);
+        $auction->update(['status' => 'closed', 'winner_bid_id' => $auction->fresh()->best_bid_id]);
+
+        // Посторонний — результаты скрыты.
+        $outsider = User::factory()->create(['email_verified_at' => now()]);
+        $this->actingAs($outsider)
+            ->get(route('auctions.show', $auction))
+            ->assertOk()
+            ->assertSee('Результаты скрыты организатором');
+
+        // Организатор и участник — видят.
+        $this->actingAs($this->organizer)
+            ->get(route('auctions.show', $auction))
+            ->assertOk()
+            ->assertDontSee('Результаты скрыты организатором');
+
+        $this->actingAs($leadUser)
+            ->get(route('auctions.show', $auction))
+            ->assertOk()
+            ->assertDontSee('Результаты скрыты организатором');
+    }
+
+    public function test_closed_commercial_auction_visible_to_invited_company_without_offers(): void
+    {
+        // #237 Участник этапа 1, не подавший ставку на этапе 2, всё равно видит итоги.
+        $auction = $this->hiddenTradingAuction();
+        [$leadUser, $leadCompany] = $this->participant($auction);
+        $this->seedLeader($auction, $leadCompany, $leadUser);
+        [$silentUser] = $this->participant($auction);
+        $auction->update(['status' => 'closed', 'winner_bid_id' => $auction->fresh()->best_bid_id]);
+
+        $this->actingAs($silentUser)
+            ->get(route('auctions.show', $auction))
+            ->assertOk()
+            ->assertDontSee('Результаты скрыты организатором');
+    }
 }


### PR DESCRIPTION
## Summary

- **#237** — у коммерческого аукциона результаты скрыты **всегда**: их видят только модераторы компании-организатора и компаний-участников. Галочка «Скрыть результаты после завершения» осталась только у обычного Запроса цен, у коммерческого — поясняющая строка.
- Флаг `is_results_hidden` ставится принудительно в `RfqController::store`, не снимается в `UpdateRfqRequest` (подделанный запрос без поля торги не раскроет) и всегда включён у аукциона этапа 2 в `CommercialAuctionLauncherService` (раньше копировался с этапа 1).
- **Видимость итогов закрытого аукциона** переведена на `Auction::resultsHiddenFor()`. Раньше участником считался только тот, кто подал ставку; теперь — приглашённая компания. Это важно для этапа 2: участники приходят с этапа 1 приглашениями, а торговать могли не все — «молчавший» участник итогов не видел.
- Миграция проставляет флаг уже созданным коммерческим RFQ и аукционам.

## Test plan

- [x] Весь набор тестов: 347/347
- [x] Pint чист (311 файлов)
- [x] Ассеты без изменений (сборка на чистом кэше вью)
- [x] +5 тестов: коммерческий RFQ создаётся со скрытыми результатами без галочки; обычный RFQ сохраняет прежнее поведение; редактирование не снимает флаг и не выводит галочку; закрытый аукцион скрыт от постороннего, но открыт организатору и участнику; приглашённый участник без ставок видит итоги

### Ручная проверка на тесте
- [ ] `/rfqs/create?procedure=commercial` — галочки «Скрыть результаты» нет, есть пояснение
- [ ] `/rfqs/create` (обычный запрос цен) — галочка на месте и работает
- [ ] Черновик коммерческого → «Редактировать» — галочки нет, флаг сохраняется
- [ ] Закрытый коммерческий аукцион: посторонний видит «Результаты скрыты организатором», организатор и участник — полные итоги

Relates to #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)