### PR TITLE
feat(commercial-auction): #195 уведомления о начале этапа 1 и о скором старте этапа 2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ php artisan config:clear && php artisan cache:clear && php artisan route:clear &
 php artisan auctions:check-expired   # Close expired auctions (manual or one-off use)
 php artisan auctions:update-statuses # Update auction statuses (scheduled every minute)
 php artisan rfqs:check-expired       # Close expired RFQs (scheduled every minute; fallback to delayed CloseRfqJob)
+php artisan commercial:notify-stages # Notify participants about stage 1 start / stage 2 in 30 min (scheduled every minute)
 php artisan rss:parse                # Parse RSS news sources (scheduled every 5 min)
 php artisan news:clean-old           # Clean old news articles (scheduled daily at 02:00)
 php artisan cleanup:test-data        # Interactive deletion of test companies (cascade soft-delete)
@@ -67,6 +68,7 @@ Configured in `bootstrap/app.php` via `withSchedule()`:
 - `rss:parse` — every 5 minutes (with `withoutOverlapping`)
 - `auctions:update-statuses` — every minute (with `withoutOverlapping`)
 - `rfqs:check-expired` — every minute (with `withoutOverlapping`) — closes RFQs whose `end_date` passed (fallback to the delayed `CloseRfqJob`)
+- `commercial:notify-stages` — every minute (with `withoutOverlapping`) — #195 notifies moderators of invited companies when stage 1 opens, and stage-1 bidders 30 min before stage 2 trading starts. Idempotent via `rfqs.stage1_notified_at` / `stage2_notified_at`
 - `news:clean-old` — daily at 02:00
 
 ### Testing PDF Generation

--- a/app/Console/Commands/NotifyCommercialStages.php
+++ b/app/Console/Commands/NotifyCommercialStages.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Rfq;
+use App\Notifications\CommercialStageOneStartedNotification;
+use App\Notifications\CommercialStageTwoSoonNotification;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Notification;
+
+/**
+ * #195 Уведомления о старте этапов коммерческого аукциона:
+ *  — этап 1: в момент начала приёма предложений, администраторам и модераторам приглашённых компаний;
+ *  — этап 2: за 30 минут до начала торгов, пользователям, подавшим предложения на этапе 1.
+ *
+ * Отметки об отправке хранятся на запросе цен (stage1_notified_at / stage2_notified_at), поэтому
+ * повторные запуски команды не рассылают одно и то же дважды.
+ */
+class NotifyCommercialStages extends Command
+{
+    protected $signature = 'commercial:notify-stages';
+
+    protected $description = 'Уведомляет участников о начале этапа 1 и о скором начале торгов этапа 2';
+
+    /** За сколько минут до начала торгов предупреждаем участников. */
+    private const STAGE_TWO_LEAD_MINUTES = 30;
+
+    public function handle(): int
+    {
+        $stageOne = $this->notifyStageOneStarted();
+        $stageTwo = $this->notifyStageTwoSoon();
+
+        $this->info("Уведомлений о старте этапа 1: {$stageOne}, о скором этапе 2: {$stageTwo}.");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Этап 1: приём предложений начался — уведомляем приглашённые компании.
+     */
+    private function notifyStageOneStarted(): int
+    {
+        $rfqs = Rfq::query()
+            ->where('procedure', Rfq::PROCEDURE_COMMERCIAL)
+            ->where('status', 'active')
+            ->whereNull('stage1_notified_at')
+            ->where('start_date', '<=', now())
+            ->with('invitations.company.moderators')
+            ->get();
+
+        foreach ($rfqs as $rfq) {
+            $recipients = $rfq->invitations
+                ->flatMap(fn ($invitation) => $invitation->company?->moderators ?? collect())
+                ->unique('id')
+                ->values();
+
+            if ($recipients->isNotEmpty()) {
+                Notification::send($recipients, new CommercialStageOneStartedNotification($rfq));
+                $this->line("Этап 1 {$rfq->number}: уведомлено получателей — {$recipients->count()}");
+            }
+
+            // Отмечаем и когда приглашённых нет (открытая процедура) — иначе перебираем каждую минуту.
+            $rfq->forceFill(['stage1_notified_at' => now()])->saveQuietly();
+        }
+
+        return $rfqs->count();
+    }
+
+    /**
+     * Этап 2: до начала торгов осталось не больше 30 минут — уведомляем подавших предложения.
+     */
+    private function notifyStageTwoSoon(): int
+    {
+        $rfqs = Rfq::query()
+            ->where('procedure', Rfq::PROCEDURE_COMMERCIAL)
+            ->whereIn('status', ['active', 'closed'])
+            ->whereNull('stage2_notified_at')
+            ->whereNotNull('trading_start')
+            ->where('trading_start', '<=', now()->addMinutes(self::STAGE_TWO_LEAD_MINUTES))
+            ->with('bids.user')
+            ->get();
+
+        foreach ($rfqs as $rfq) {
+            $recipients = $rfq->bids
+                ->map(fn ($bid) => $bid->user)
+                ->filter()
+                ->unique('id')
+                ->values();
+
+            if ($recipients->isNotEmpty()) {
+                Notification::send($recipients, new CommercialStageTwoSoonNotification($rfq));
+                $this->line("Этап 2 {$rfq->number}: уведомлено получателей — {$recipients->count()}");
+            }
+
+            // Предложений может не быть вовсе — этап 2 тогда не состоится, но отметку ставим,
+            // чтобы не перебирать процедуру каждую минуту.
+            $rfq->forceFill(['stage2_notified_at' => now()])->saveQuietly();
+        }
+
+        return $rfqs->count();
+    }
+}

--- a/app/Models/Rfq.php
+++ b/app/Models/Rfq.php
@@ -61,6 +61,9 @@ class Rfq extends Model implements HasMedia
         'step_price' => 'decimal:2',
         'step_advance' => 'decimal:2',
         'is_results_hidden' => 'boolean',
+        // #195 Отметки об отправленных уведомлениях о старте этапов.
+        'stage1_notified_at' => 'datetime',
+        'stage2_notified_at' => 'datetime',
     ];
 
     public const PROCEDURE_STANDARD = 'standard';

--- a/app/Notifications/CommercialStageOneStartedNotification.php
+++ b/app/Notifications/CommercialStageOneStartedNotification.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\Rfq;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * #195 Начался приём предложений (этап 1 коммерческого аукциона).
+ * Уходит администраторам и модераторам приглашённых компаний в момент наступления start_date.
+ */
+class CommercialStageOneStartedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Rfq $rfq) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database', 'mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Начался приём предложений: '.$this->rfq->title)
+            ->greeting('Здравствуйте!')
+            ->line('Открыт приём предложений на этапе 1 коммерческого аукциона, к участию в котором приглашена ваша компания.')
+            ->line('**Номер:** '.$this->rfq->number)
+            ->line('**Название:** '.$this->rfq->title)
+            ->line('**Приём предложений до:** '.$this->rfq->end_date->format('d.m.Y H:i').' (МСК)')
+            ->action('Подать предложение', route('rfqs.show', $this->rfq))
+            ->line('На этапе 1 оценивается только цена. По его итогам автоматически начнутся торги этапа 2.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'type' => 'commercial_stage1_started',
+            'rfq_id' => $this->rfq->id,
+            'rfq_number' => $this->rfq->number,
+            'rfq_title' => $this->rfq->title,
+            'end_date' => $this->rfq->end_date->toIso8601String(),
+            'url' => route('rfqs.show', $this->rfq),
+        ];
+    }
+}

--- a/app/Notifications/CommercialStageTwoSoonNotification.php
+++ b/app/Notifications/CommercialStageTwoSoonNotification.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\Rfq;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * #195 Торги этапа 2 начнутся через 30 минут.
+ * Уходит пользователям, подавшим предложения на этапе 1.
+ */
+class CommercialStageTwoSoonNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public Rfq $rfq) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['database', 'mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Через 30 минут начнутся торги: '.$this->rfq->title)
+            ->greeting('Здравствуйте!')
+            ->line('Скоро начнутся торги этапа 2 коммерческого аукциона, в котором вы подали предложение.')
+            ->line('**Номер:** '.$this->rfq->number)
+            ->line('**Название:** '.$this->rfq->title)
+            ->line('**Начало торгов:** '.$this->rfq->trading_start->format('d.m.Y H:i').' (МСК)')
+            ->action('Перейти к процедуре', $this->url())
+            ->line('На этапе 2 предложение улучшается в реальном времени по трём критериям: цена, срок и аванс.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'type' => 'commercial_stage2_soon',
+            'rfq_id' => $this->rfq->id,
+            'rfq_number' => $this->rfq->number,
+            'rfq_title' => $this->rfq->title,
+            'trading_start' => $this->rfq->trading_start->toIso8601String(),
+            'url' => $this->url(),
+        ];
+    }
+
+    /**
+     * Аукцион этапа 2 к моменту отправки может быть ещё не создан (он рождается при закрытии
+     * этапа 1) — тогда ведём на страницу этапа 1, она сама откроет торги при их старте (#205).
+     */
+    private function url(): string
+    {
+        return $this->rfq->linked_auction_id
+            ? route('auctions.show', $this->rfq->linked_auction_id)
+            : route('rfqs.show', $this->rfq);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -45,6 +45,12 @@ return Application::configure(basePath: dirname(__DIR__))
             ->dailyAt('03:00')
             ->withoutOverlapping();
 
+        // #195 Уведомления о старте этапа 1 и о начале торгов этапа 2 (за 30 минут)
+        $schedule->command('commercial:notify-stages')
+            ->everyMinute()
+            ->withoutOverlapping()
+            ->runInBackground();
+
     })
     ->withExceptions(function (Exceptions $exceptions) {
         // 419 CSRF token expired → redirect to login instead of error page

--- a/database/migrations/2026_08_06_100000_add_stage_notification_marks_to_rfqs_table.php
+++ b/database/migrations/2026_08_06_100000_add_stage_notification_marks_to_rfqs_table.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * #195 Отметки об отправленных уведомлениях о старте этапов коммерческого аукциона.
+ * Хранятся на запросе цен (этап 1): уведомление о скором старте этапа 2 уходит за 30 минут,
+ * а аукцион этапа 2 к этому моменту может быть ещё не создан (при коротком зазоре между
+ * окончанием приёма и началом торгов — по умолчанию 10 минут, #222).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('rfqs', function (Blueprint $table) {
+            $table->timestamp('stage1_notified_at')->nullable()->after('linked_auction_id');
+            $table->timestamp('stage2_notified_at')->nullable()->after('stage1_notified_at');
+        });
+
+        // Существующие процедуры не должны получить «задним числом» пачку уведомлений:
+        // помечаем отправленными те события, момент которых уже прошёл.
+        $now = now();
+
+        DB::table('rfqs')
+            ->where('procedure', 'commercial')
+            ->where('start_date', '<=', $now)
+            ->update(['stage1_notified_at' => $now]);
+
+        DB::table('rfqs')
+            ->where('procedure', 'commercial')
+            ->whereNotNull('trading_start')
+            ->where('trading_start', '<=', $now->copy()->addMinutes(30))
+            ->update(['stage2_notified_at' => $now]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('rfqs', function (Blueprint $table) {
+            $table->dropColumn(['stage1_notified_at', 'stage2_notified_at']);
+        });
+    }
+};

--- a/docs/CHANGELOG_CLAUDE.md
+++ b/docs/CHANGELOG_CLAUDE.md
@@ -2607,3 +2607,34 @@ read-only — смена организатора ломала бы пригла
 **Файлы:** `resources/views/auctions/show.blade.php`,
 `tests/Feature/CommercialHiddenResultsTest.php` (+1 тест).
 Прогон: весь набор 362/362. Pint чист, ассеты без изменений.
+
+---
+
+## 2026-08-06 — feat #195: уведомления о начале этапов коммерческого аукциона
+
+**Задача:** уведомлять администраторов и модераторов приглашённых компаний в момент начала приёма
+предложений (этап 1) и пользователей, подавших предложения, — за 30 минут до начала торгов (этап 2).
+
+**Сделано:** команда `commercial:notify-stages` (в планировщике каждую минуту, `withoutOverlapping`)
+и два уведомления (`database` + `mail`):
+- `CommercialStageOneStartedNotification` — при наступлении `start_date` активной коммерческой
+  процедуры уходит модераторам всех приглашённых компаний;
+- `CommercialStageTwoSoonNotification` — когда до `trading_start` осталось не больше 30 минут,
+  уходит пользователям, подавшим предложения на этапе 1.
+
+**Почему отметки на запросе цен, а не на аукционе.** Аукцион этапа 2 рождается только при закрытии
+этапа 1, а по умолчанию (#222) торги начинаются через 10 минут после окончания приёма — то есть
+момент «за 30 минут» наступает, когда аукциона ещё не существует. Поэтому и получатели, и время
+берутся с запроса цен, а ссылка ведёт на аукцион, если он уже создан, иначе на страницу этапа 1
+(она сама откроет торги при старте, #205).
+
+Повторные запуски безопасны: отметки `rfqs.stage1_notified_at` / `stage2_notified_at`. Миграция
+проставляет их существующим процедурам, у которых событие уже прошло, — чтобы при выкатке не ушла
+пачка уведомлений задним числом.
+
+**Файлы:** `app/Console/Commands/NotifyCommercialStages.php`,
+`app/Notifications/CommercialStageOneStartedNotification.php`,
+`app/Notifications/CommercialStageTwoSoonNotification.php`, `bootstrap/app.php`, `app/Models/Rfq.php`,
+`database/migrations/2026_08_06_100000_add_stage_notification_marks_to_rfqs_table.php`,
+`CLAUDE.md`, `tests/Feature/CommercialStageNotificationsTest.php` (новый, 9 тестов).
+Прогон: весь набор 371/371. Pint чист, ассеты без изменений.

--- a/tests/Feature/CommercialStageNotificationsTest.php
+++ b/tests/Feature/CommercialStageNotificationsTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\Rfq;
+use App\Models\RfqBid;
+use App\Models\User;
+use App\Notifications\CommercialStageOneStartedNotification;
+use App\Notifications\CommercialStageTwoSoonNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+/**
+ * #195 Уведомления о старте этапов коммерческого аукциона.
+ */
+class CommercialStageNotificationsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $organizer;
+
+    private Company $company;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->organizer = User::factory()->create(['email_verified_at' => now()]);
+        $this->company = Company::factory()->create([
+            'created_by' => $this->organizer->id,
+            'is_verified' => true,
+        ]);
+        $this->company->assignModerator($this->organizer, 'owner');
+
+        Notification::fake();
+    }
+
+    private function commercialRfq(array $overrides = []): Rfq
+    {
+        return Rfq::create(array_merge([
+            'number' => Rfq::generateNumber(),
+            'title' => 'Коммерческий аукцион',
+            'company_id' => $this->company->id,
+            'created_by' => $this->organizer->id,
+            'type' => 'closed',
+            'procedure' => Rfq::PROCEDURE_COMMERCIAL,
+            'currency' => 'RUB',
+            'start_date' => now()->subMinute(),
+            'end_date' => now()->addDay(),
+            'trading_start' => now()->addDay()->addMinutes(10),
+            'weight_price' => 70, 'weight_deadline' => 20, 'weight_advance' => 10,
+            'step_price' => 0.5, 'step_deadline' => 1, 'step_advance' => 5,
+            'max_deadline' => 90, 'max_advance' => 100,
+            'status' => 'active',
+        ], $overrides));
+    }
+
+    /** @return array{0: User, 1: Company} */
+    private function invitedCompany(Rfq $rfq): array
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+        $company = Company::factory()->create(['created_by' => $user->id, 'is_verified' => true]);
+        $company->assignModerator($user, 'owner');
+
+        $rfq->invitations()->create([
+            'company_id' => $company->id,
+            'invited_by' => $this->organizer->id,
+            'status' => 'pending',
+        ]);
+
+        return [$user, $company];
+    }
+
+    private function bid(Rfq $rfq, Company $company, User $user): RfqBid
+    {
+        return RfqBid::create([
+            'rfq_id' => $rfq->id,
+            'company_id' => $company->id,
+            'user_id' => $user->id,
+            'price' => 500_000,
+            'status' => 'pending',
+        ]);
+    }
+
+    // ==========================================================
+    // Этап 1 — начало приёма предложений
+    // ==========================================================
+
+    public function test_stage1_start_notifies_moderators_of_invited_companies(): void
+    {
+        $rfq = $this->commercialRfq();
+        [$invitedUser] = $this->invitedCompany($rfq);
+
+        $this->artisan('commercial:notify-stages')->assertSuccessful();
+
+        Notification::assertSentTo($invitedUser, CommercialStageOneStartedNotification::class);
+        $this->assertNotNull($rfq->fresh()->stage1_notified_at);
+    }
+
+    public function test_stage1_notification_is_not_sent_before_start_date(): void
+    {
+        $rfq = $this->commercialRfq(['start_date' => now()->addHour()]);
+        [$invitedUser] = $this->invitedCompany($rfq);
+
+        $this->artisan('commercial:notify-stages')->assertSuccessful();
+
+        Notification::assertNotSentTo($invitedUser, CommercialStageOneStartedNotification::class);
+        $this->assertNull($rfq->fresh()->stage1_notified_at);
+    }
+
+    public function test_stage1_notification_is_sent_only_once(): void
+    {
+        $rfq = $this->commercialRfq();
+        [$invitedUser] = $this->invitedCompany($rfq);
+
+        $this->artisan('commercial:notify-stages')->assertSuccessful();
+        $this->artisan('commercial:notify-stages')->assertSuccessful();
+
+        Notification::assertSentToTimes($invitedUser, CommercialStageOneStartedNotification::class, 1);
+    }
+
+    public function test_stage1_notification_skips_draft_and_standard_procedures(): void
+    {
+        $draft = $this->commercialRfq(['status' => 'draft']);
+        [$draftUser] = $this->invitedCompany($draft);
+
+        $standard = $this->commercialRfq(['procedure' => Rfq::PROCEDURE_STANDARD, 'trading_start' => null]);
+        [$standardUser] = $this->invitedCompany($standard);
+
+        $this->artisan('commercial:notify-stages')->assertSuccessful();
+
+        Notification::assertNotSentTo($draftUser, CommercialStageOneStartedNotification::class);
+        Notification::assertNotSentTo($standardUser, CommercialStageOneStartedNotification::class);
+    }
+
+    // ==========================================================
+    // Этап 2 — за 30 минут до начала торгов
+    // ==========================================================
+
+    public function test_stage2_notification_goes_to_bidders_30_minutes_before_trading(): void
+    {
+        $rfq = $this->commercialRfq(['trading_start' => now()->addMinutes(25)]);
+        [$bidderUser, $bidderCompany] = $this->invitedCompany($rfq);
+        $this->bid($rfq, $bidderCompany, $bidderUser);
+
+        $this->artisan('commercial:notify-stages')->assertSuccessful();
+
+        Notification::assertSentTo($bidderUser, CommercialStageTwoSoonNotification::class);
+        $this->assertNotNull($rfq->fresh()->stage2_notified_at);
+    }
+
+    public function test_stage2_notification_is_not_sent_too_early(): void
+    {
+        $rfq = $this->commercialRfq(['trading_start' => now()->addHours(2)]);
+        [$bidderUser, $bidderCompany] = $this->invitedCompany($rfq);
+        $this->bid($rfq, $bidderCompany, $bidderUser);
+
+        $this->artisan('commercial:notify-stages')->assertSuccessful();
+
+        Notification::assertNotSentTo($bidderUser, CommercialStageTwoSoonNotification::class);
+        $this->assertNull($rfq->fresh()->stage2_notified_at);
+    }
+
+    public function test_stage2_notification_skips_companies_without_offers(): void
+    {
+        // Приглашённый, но не подавший предложение, к торгам этапа 2 не допускается — не уведомляем.
+        $rfq = $this->commercialRfq(['trading_start' => now()->addMinutes(25)]);
+        [$silentUser] = $this->invitedCompany($rfq);
+        [$bidderUser, $bidderCompany] = $this->invitedCompany($rfq);
+        $this->bid($rfq, $bidderCompany, $bidderUser);
+
+        $this->artisan('commercial:notify-stages')->assertSuccessful();
+
+        Notification::assertSentTo($bidderUser, CommercialStageTwoSoonNotification::class);
+        Notification::assertNotSentTo($silentUser, CommercialStageTwoSoonNotification::class);
+    }
+
+    public function test_stage2_notification_is_sent_only_once(): void
+    {
+        $rfq = $this->commercialRfq(['trading_start' => now()->addMinutes(25)]);
+        [$bidderUser, $bidderCompany] = $this->invitedCompany($rfq);
+        $this->bid($rfq, $bidderCompany, $bidderUser);
+
+        $this->artisan('commercial:notify-stages')->assertSuccessful();
+        $this->artisan('commercial:notify-stages')->assertSuccessful();
+
+        Notification::assertSentToTimes($bidderUser, CommercialStageTwoSoonNotification::class, 1);
+    }
+
+    public function test_stage2_notification_is_sent_after_stage1_closed(): void
+    {
+        // При коротком зазоре (по умолчанию 10 минут, #222) момент «за 30 минут» наступает ещё
+        // до закрытия этапа 1, но процедура может дожить до закрытия — уведомление всё равно уходит.
+        $rfq = $this->commercialRfq([
+            'status' => 'closed',
+            'end_date' => now()->subMinutes(5),
+            'trading_start' => now()->addMinutes(5),
+        ]);
+        [$bidderUser, $bidderCompany] = $this->invitedCompany($rfq);
+        $this->bid($rfq, $bidderCompany, $bidderUser);
+
+        $this->artisan('commercial:notify-stages')->assertSuccessful();
+
+        Notification::assertSentTo($bidderUser, CommercialStageTwoSoonNotification::class);
+    }
+}


### PR DESCRIPTION
## Summary

- **#195** — команда `commercial:notify-stages` (в планировщике каждую минуту, `withoutOverlapping`) и два уведомления (`database` + `mail`):
  - **Этап 1** — при наступлении `start_date` активной коммерческой процедуры уведомление уходит администраторам и модераторам всех приглашённых компаний.
  - **Этап 2** — когда до `trading_start` остаётся не больше 30 минут, уведомление уходит пользователям, подавшим предложения на этапе 1.

**Почему отметки живут на запросе цен, а не на аукционе.** Аукцион этапа 2 рождается только при закрытии этапа 1, а по умолчанию (#222) торги начинаются через 10 минут после окончания приёма — то есть момент «за 30 минут» наступает, когда аукциона ещё не существует. Поэтому получатели и время берутся с запроса цен, а ссылка ведёт на аукцион, если он уже создан, иначе на страницу этапа 1 (она сама откроет торги при старте, #205).

**Идемпотентность.** Повторные запуски безопасны: отметки `rfqs.stage1_notified_at` / `stage2_notified_at`. Отметка ставится и когда получателей нет (открытая процедура без приглашений, процедура без предложений) — иначе команда перебирала бы её каждую минуту.

**Миграция** проставляет отметки существующим процедурам, у которых событие уже прошло, — чтобы при выкатке не ушла пачка уведомлений задним числом.

**Область действия.** Реализовано для коммерческой процедуры, как и сформулировано в задаче («этап 1» / «этап 2»). Для обычного Запроса цен уведомление о начале приёма сейчас не отправляется — приглашённые получают письмо в момент приглашения. Если нужно и там, это добавление одного условия.

## Test plan

- [x] Весь набор тестов: 371/371
- [x] Pint чист (316 файлов), ассеты без изменений
- [x] Новый `CommercialStageNotificationsTest` — 9 тестов: уведомление этапа 1 уходит модераторам приглашённых компаний; не уходит до `start_date`; не дублируется; черновики и обычные запросы цен пропускаются; уведомление этапа 2 уходит подавшим предложения за 30 минут, не уходит заранее, не уходит приглашённым без предложений, не дублируется, работает и после закрытия этапа 1

### Ручная проверка на тесте
- [ ] Создать коммерческий аукцион со стартом через пару минут, пригласить компанию → в момент старта её модераторам приходит уведомление (колокольчик + почта)
- [ ] Подать предложение, дождаться отметки «30 минут до торгов» → участнику приходит уведомление со ссылкой на процедуру
- [ ] Повторные тики планировщика уведомления не дублируют

Relates to #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)